### PR TITLE
New Pricing - interest rate fixed / RM variable

### DIFF
--- a/contracts/Policy.sol
+++ b/contracts/Policy.sol
@@ -68,11 +68,23 @@ library Policy {
     .rayToWad();
     policy.premiumForEnsuro = policy.purePremium.wadMul(riskModule.ensuroFee().rayToWad());
     policy.premiumForLps = policy.scr.wadMul(
-      ((riskModule.scrInterestRate() * (policy.expiration - policy.start)).rayDiv(SECONDS_IN_YEAR_RAY)).rayToWad()
+      (
+        (riskModule.scrInterestRate() * (policy.expiration - policy.start)).rayDiv(
+          SECONDS_IN_YEAR_RAY
+        )
+      )
+      .rayToWad()
     );
-    require(policy.purePremium + policy.premiumForEnsuro + policy.premiumForLps <= ensPremium,
-            "Premium less than minimum");
-    policy.premiumForRm = rmPremium + ensPremium - policy.purePremium - policy.premiumForLps - policy.premiumForEnsuro;
+    require(
+      policy.purePremium + policy.premiumForEnsuro + policy.premiumForLps <= ensPremium,
+      "Premium less than minimum"
+    );
+    policy.premiumForRm =
+      rmPremium +
+      ensPremium -
+      policy.purePremium -
+      policy.premiumForLps -
+      policy.premiumForEnsuro;
     return policy;
   }
 

--- a/contracts/RiskModule.sol
+++ b/contracts/RiskModule.sol
@@ -39,8 +39,8 @@ abstract contract RiskModule is
   // capital requirement as % of (payout - premium)
   uint256 internal _moc; // in ray - Margin Of Conservativism - factor that multiplies lossProb
   // to calculate purePremium
-  uint256 internal _premiumShare; // in ray - % of premium that will go for the risk module provider
-  uint256 internal _ensuroShare; // in ray - % of premium that will go for Ensuro treasury
+  uint256 internal _ensuroFee; // in ray - % of pure premium that will go for Ensuro treasury
+  uint256 internal _scrInterestRate; // in ray - % of interest to charge for the SCR
   uint256 internal _maxScrPerPolicy; // in wad - Max SCR per policy
   uint256 internal _scrLimit; // in wad - Max SCR to be allocated to this module
   uint256 internal _totalScr; // in wad - Current SCR allocated to this module
@@ -61,8 +61,8 @@ abstract contract RiskModule is
    * @param policyPool_ The address of the Ensuro PolicyPool where this module is plugged
    * @param scrPercentage_ Solvency Capital Requirement percentage, to calculate
                           capital requirement as % of (payout - premium)  (in ray)
-   * @param premiumShare_ % of premium that will go for the risk module provider (in ray)
-   * @param ensuroShare_ % of premium that will go for Ensuro treasury (in ray)
+   * @param ensuroFee_ % of pure premium that will go for Ensuro treasury (in ray)
+   * @param scrInterestRate_ % of interest to charge for the SCR (in ray)
    * @param maxScrPerPolicy_ Max SCR to be allocated to this module (in wad)
    * @param scrLimit_ Max SCR to be allocated to this module (in wad)
    * @param wallet_ Address of the RiskModule provider
@@ -73,8 +73,8 @@ abstract contract RiskModule is
     string memory name_,
     IPolicyPool policyPool_,
     uint256 scrPercentage_,
-    uint256 premiumShare_,
-    uint256 ensuroShare_,
+    uint256 ensuroFee_,
+    uint256 scrInterestRate_,
     uint256 maxScrPerPolicy_,
     uint256 scrLimit_,
     address wallet_,
@@ -87,8 +87,8 @@ abstract contract RiskModule is
       name_,
       policyPool_,
       scrPercentage_,
-      premiumShare_,
-      ensuroShare_,
+      ensuroFee_,
+      scrInterestRate_,
       maxScrPerPolicy_,
       scrLimit_,
       wallet_,
@@ -101,8 +101,8 @@ abstract contract RiskModule is
     string memory name_,
     IPolicyPool policyPool_,
     uint256 scrPercentage_,
-    uint256 premiumShare_,
-    uint256 ensuroShare_,
+    uint256 ensuroFee_,
+    uint256 scrInterestRate_,
     uint256 maxScrPerPolicy_,
     uint256 scrLimit_,
     address wallet_,
@@ -112,8 +112,8 @@ abstract contract RiskModule is
     _policyPool = policyPool_;
     _scrPercentage = scrPercentage_;
     _moc = WadRayMath.RAY;
-    _premiumShare = premiumShare_;
-    _ensuroShare = ensuroShare_;
+    _ensuroFee = ensuroFee_;
+    _scrInterestRate = scrInterestRate_;
     _maxScrPerPolicy = maxScrPerPolicy_;
     _scrLimit = scrLimit_;
     _totalScr = 0;
@@ -144,12 +144,12 @@ abstract contract RiskModule is
     return _moc;
   }
 
-  function premiumShare() public view override returns (uint256) {
-    return _premiumShare;
+  function ensuroFee() public view override returns (uint256) {
+    return _ensuroFee;
   }
 
-  function ensuroShare() public view override returns (uint256) {
-    return _ensuroShare;
+  function scrInterestRate() public view override returns (uint256) {
+    return _scrInterestRate;
   }
 
   function maxScrPerPolicy() public view override returns (uint256) {
@@ -190,14 +190,14 @@ abstract contract RiskModule is
     _moc = newMoc;
   }
 
-  function setPremiumShare(uint256 newPremiumShare) external onlyRole(ENSURO_DAO_ROLE) {
+  function setScrInterestRate(uint256 newScrInterestRate) external onlyRole(ENSURO_DAO_ROLE) {
     // TODO emit Event?
-    _premiumShare = newPremiumShare;
+    _scrInterestRate = newScrInterestRate;
   }
 
-  function setEnsuroShare(uint256 newEnsuroShare) external onlyRole(ENSURO_DAO_ROLE) {
+  function setEnsuroFee(uint256 newEnsuroFee) external onlyRole(ENSURO_DAO_ROLE) {
     // TODO emit Event?
-    _ensuroShare = newEnsuroShare;
+    _ensuroFee = newEnsuroFee;
   }
 
   function setMaxScrPerPolicy(uint256 newMaxScrPerPolicy) external onlyRole(ENSURO_DAO_ROLE) {

--- a/contracts/TrustfulRiskModule.sol
+++ b/contracts/TrustfulRiskModule.sol
@@ -21,8 +21,8 @@ contract TrustfulRiskModule is RiskModule {
    * @param policyPool_ The address of the Ensuro PolicyPool where this module is plugged
    * @param scrPercentage_ Solvency Capital Requirement percentage, to calculate
                           capital requirement as % of (payout - premium)  (in ray)
-   * @param premiumShare_ % of premium that will go for the risk module provider (in ray)
-   * @param ensuroShare_ % of premium that will go for Ensuro treasury (in ray)
+   * @param ensuroFee_ % of premium that will go for Ensuro treasury (in ray)
+   * @param scrInterestRate_ cost of capital (in ray)
    * @param maxScrPerPolicy_ Max SCR to be allocated to this module (in wad)
    * @param scrLimit_ Max SCR to be allocated to this module (in wad)
    * @param wallet_ Address of the RiskModule provider
@@ -32,8 +32,8 @@ contract TrustfulRiskModule is RiskModule {
     string memory name_,
     IPolicyPool policyPool_,
     uint256 scrPercentage_,
-    uint256 premiumShare_,
-    uint256 ensuroShare_,
+    uint256 ensuroFee_,
+    uint256 scrInterestRate_,
     uint256 maxScrPerPolicy_,
     uint256 scrLimit_,
     address wallet_,
@@ -43,8 +43,8 @@ contract TrustfulRiskModule is RiskModule {
       name_,
       policyPool_,
       scrPercentage_,
-      premiumShare_,
-      ensuroShare_,
+      ensuroFee_,
+      scrInterestRate_,
       maxScrPerPolicy_,
       scrLimit_,
       wallet_,

--- a/interfaces/IRiskModule.sol
+++ b/interfaces/IRiskModule.sol
@@ -13,9 +13,9 @@ interface IRiskModule {
 
   function moc() external view returns (uint256);
 
-  function premiumShare() external view returns (uint256);
+  function ensuroFee() external view returns (uint256);
 
-  function ensuroShare() external view returns (uint256);
+  function scrInterestRate() external view returns (uint256);
 
   function maxScrPerPolicy() external view returns (uint256);
 

--- a/prototype/contracts.py
+++ b/prototype/contracts.py
@@ -45,6 +45,9 @@ class ContractProxy(str):
     def __getattr__(self, attr_name):
         return getattr(self._get_contract(), attr_name)
 
+    def __setattr__(self, attr_name, attr_value):
+        return setattr(self._get_contract(), attr_name, attr_value)
+
 
 class ContractProxyField(AddressField):
     FIELD_TYPE = ContractProxy

--- a/prototype/wadray.py
+++ b/prototype/wadray.py
@@ -62,6 +62,11 @@ class Wad(int):
     def to_decimal(self):
         return Decimal(int(self)) / Decimal(WAD)
 
+    def round(self, decimals):
+        iself = int(self)
+        iself = iself - iself % 10 ** (18 - decimals)
+        return Wad(iself)
+
 
 class Ray(int):
     DEFAULT_EQ_PRECISION = 4
@@ -119,6 +124,11 @@ class Ray(int):
 
     def to_decimal(self):
         return Decimal(int(self)) / Decimal(RAY)
+
+    def round(self, decimals):
+        iself = int(self)
+        iself = iself - iself % 10 ** (27 - decimals)
+        return Ray(iself)
 
 
 _R = Ray.from_value

--- a/tests/wrappers.py
+++ b/tests/wrappers.py
@@ -491,26 +491,27 @@ class Policy:
 
 class RiskModuleETH(ETHWrapper):
 
-    def __init__(self, name, policy_pool, scr_percentage=_R(1), premium_share=_R(0), ensuro_share=_R(0),
-                 max_scr_per_policy=_W(1000000), scr_limit=_W(1000000),
+    def __init__(self, name, policy_pool, scr_percentage=_R(1), ensuro_fee=_R(0),
+                 scr_interest_rate=_R(0), max_scr_per_policy=_W(1000000), scr_limit=_W(1000000),
                  wallet="RM", shared_coverage_min_percentage=_R(0), owner="owner"):
         scr_percentage = _R(scr_percentage)
-        premium_share = _R(premium_share)
-        ensuro_share = _R(ensuro_share)
+        ensuro_fee = _R(ensuro_fee)
+        scr_interest_rate = _R(scr_interest_rate)
         max_scr_per_policy = _W(max_scr_per_policy)
         scr_limit = _W(scr_limit)
         wallet = self._get_account(wallet)
         shared_coverage_min_percentage = _R(shared_coverage_min_percentage)
         self.policy_pool = policy_pool
-        super().__init__(owner, name, policy_pool.contract, scr_percentage, premium_share, ensuro_share,
+        super().__init__(owner, name, policy_pool.contract, scr_percentage, ensuro_fee,
+                         scr_interest_rate,
                          max_scr_per_policy, scr_limit, wallet, shared_coverage_min_percentage)
         self._auto_from = self.owner
 
     name = MethodAdapter((), "string", is_property=True)
     scr_percentage = MethodAdapter((), "ray", is_property=True)
     moc = MethodAdapter((), "ray", is_property=True)
-    premium_share = MethodAdapter((), "ray", is_property=True)
-    ensuro_share = MethodAdapter((), "ray", is_property=True)
+    ensuro_fee = MethodAdapter((), "ray", is_property=True)
+    scr_interest_rate = MethodAdapter((), "ray", is_property=True)
     max_scr_per_policy = MethodAdapter((), "amount", is_property=True)
     scr_limit = MethodAdapter((), "amount", is_property=True)
     total_scr = MethodAdapter((), "amount", is_property=True)


### PR DESCRIPTION
New pricing strategy. Now each RiskModule has a fixed interest rate that
has to pay for the capital locked (SCR).

Also renamed `ensuro_share` to `ensuro_fee` and now is calculated as a
percentage of pure premium.

Finally, removed premium_share (the share for RM), because now that is
variable, is whatever exceeds the pure_premium + ensuro_fee + capital
cost.