### PR TITLE
Removing CHECKPOINT_ROLE required for AssetManager

### DIFF
--- a/contracts/BaseAssetManager.sol
+++ b/contracts/BaseAssetManager.sol
@@ -125,7 +125,8 @@ abstract contract BaseAssetManager is
   /**
    * @dev Calculates asset earnings and distributes them updating accounting in PolicyPool and eTokens
    */
-  function distibuteEarnings() public virtual whenNotPaused onlyRole(CHECKPOINT_ROLE) {
+  function distibuteEarnings() public virtual whenNotPaused {
+    // TODO Check: Anyone can call this funcion. This could be a potencial surface of flash loan attack?
     uint256 investmentValue = getInvestmentValue();
     bool positive;
     uint256 earnings;
@@ -160,7 +161,8 @@ abstract contract BaseAssetManager is
   /**
    * @dev Rebalances cash between PolicyPool wallet and
    */
-  function rebalance() public virtual whenNotPaused onlyRole(CHECKPOINT_ROLE) {
+  function rebalance() public virtual whenNotPaused {
+    // TODO Check: Anyone can call this funcion. This could be a potencial surface of flash loan attack?
     uint256 poolCash = _currency().balanceOf(address(_policyPool));
     if (poolCash > _liquidityMax) {
       _invest(poolCash - _liquidityMiddle);

--- a/prototype/ensuro.py
+++ b/prototype/ensuro.py
@@ -715,7 +715,6 @@ class AssetManager(AccessControlContract):
 
         return pool_investable + token_investable
 
-    @only_role("CHECKPOINT_ROLE")
     def distribute_earnings(self):
         investment_value = self.get_investment_value()
         total_investable = self.total_investable()
@@ -732,7 +731,6 @@ class AssetManager(AccessControlContract):
     def get_investment_value(self):
         raise NotImplementedError()
 
-    @only_role("CHECKPOINT_ROLE")
     def rebalance(self):
         pool_cash = self.pool.currency.balance_of(self.pool.contract_id)
 


### PR DESCRIPTION
Now the operations of AssetManager that distribute earnings and
rebalance cash between the asset manager and the PolicyPool are open to
anyone who pays the gas.