### PR TITLE
Expire Policy and Withdraw Won Premiums

### DIFF
--- a/tests/test_policypool.py
+++ b/tests/test_policypool.py
@@ -1061,3 +1061,104 @@ def test_lp_insolvency_hook_other_etk(tenv):
     etk1m.get_pool_loan().assert_equal(
         _W(4000) - (_W(5000) - pool_loan_1y) + _W(4000) * _W(0.04 * 30/365)
     )
+
+
+def test_expire_policy(tenv):
+    YAML_SETUP = """
+    risk_modules:
+      - name: Flight Insurance
+        scr_percentage: "0.1"
+        ensuro_fee: "0.05"
+        scr_interest_rate: "0.01"
+        wallet: "MGA"
+    currency:
+        name: USD
+        symbol: $
+        initial_supply: 6000
+        initial_balances:
+        - user: LP1
+          amount: 1000
+        - user: LP2
+          amount: 1000
+        - user: LP3
+          amount: 1000
+        - user: CUST1
+          amount: 100
+    etokens:
+      - name: eUSD1YEAR
+        expiration_period: 31536000
+    """
+
+    pool = load_config(StringIO(YAML_SETUP), tenv.module)
+    timecontrol = tenv.time_control
+    etk = pool.etokens["eUSD1YEAR"]
+    USD = pool.currency
+    rm = pool.config.risk_modules["Flight Insurance"]
+    rm.grant_role("PRICER_ROLE", rm.owner)
+    rm.grant_role("RESOLVER_ROLE", rm.owner)
+    pool.config.grant_role("LEVEL2_ROLE", rm.owner)  # For setting moc
+
+    with rm.as_(rm.owner):
+        rm.moc = _R("1.1")
+
+    pool.currency.approve("LP1", pool.contract_id, _W(1000))
+
+    assert pool.deposit("eUSD1YEAR", "LP1", _W(1000)) == _W(1000)
+
+    pool.currency.approve("CUST1", pool.contract_id, _W(100))
+    policy = rm.new_policy(
+        payout=_W(2100), premium=_W(100), customer="CUST1",
+        loss_prob=_R("0.03"), expiration=timecontrol.now + 10 * DAY
+    )
+    policy.scr.assert_equal(_W(200))
+    etk.scr.assert_equal(_W(200))
+    pure_premium, for_ensuro, for_rm, for_lps = policy.premium_split()
+
+    for_lps.assert_equal(_W(200) * _W("0.01") * _W(10/365))
+    pure_premium.assert_equal(_W(2100) * _W("0.03") * _W("1.1"))
+    for_ensuro.assert_equal(pure_premium * _W("0.05"))
+    for_rm.assert_equal(_W(100) - for_lps - for_ensuro - pure_premium)
+
+    timecontrol.fast_forward(4 * DAY)
+
+    with pytest.raises(RevertError, match="Policy not expired yet"):
+        pool.expire_policy(policy.id)
+
+    timecontrol.fast_forward(7 * DAY)
+
+    pool.expire_policy(policy.id)
+    etk.scr.assert_equal(_W(0))
+    etk.ocean.assert_equal(_W(1000) + for_lps)
+
+    USD.balance_of("ENS").assert_equal(for_ensuro)
+    USD.balance_of("MGA").assert_equal(for_rm)
+    USD.balance_of("CUST1").assert_equal(_W(0))
+    pool.won_pure_premiums.assert_equal(pure_premium)
+
+    return locals()
+
+
+def test_withdraw_won_premiums(tenv):
+    vars = test_expire_policy(tenv)
+    pool, rm, etk, for_lps, policy, USD, timecontrol = _extract_vars(
+        vars, "pool,rm,etk,for_lps,policy,USD,timecontrol"
+    )
+    treasury_balance = USD.balance_of("ENS")
+    won_pure_premiums = pool.won_pure_premiums
+
+    with pytest.raises(RevertError, match="AccessControl"):
+        pool.withdraw_won_premiums(_W(1))
+
+    pool.config.grant_role("WITHDRAW_WON_PREMIUMS_ROLE", "PREMIUM_WITHDRAWER")
+
+    with pool.as_("PREMIUM_WITHDRAWER"):
+        pool.withdraw_won_premiums(_W(10)).assert_equal(_W(10))
+
+    USD.balance_of("ENS").assert_equal(treasury_balance + _W(10))
+    pool.won_pure_premiums.assert_equal(won_pure_premiums - _W(10))
+
+    with pool.as_("PREMIUM_WITHDRAWER"):
+        pool.withdraw_won_premiums(_W(999999)).assert_equal(won_pure_premiums - _W(10))
+
+    USD.balance_of("ENS").assert_equal(treasury_balance + won_pure_premiums)
+    pool.won_pure_premiums.assert_equal(0)

--- a/tests/wrappers.py
+++ b/tests/wrappers.py
@@ -699,6 +699,15 @@ class PolicyPool(ETHWrapper):
         else:
             return Wad(0)
 
+    withdraw_won_premiums_ = MethodAdapter((("amount", "amount"), ))
+
+    def withdraw_won_premiums(self, amount):
+        receipt = self.withdraw_won_premiums_(amount)
+        if "WonPremiumsInOut" in receipt.events:
+            return Wad(receipt.events["WonPremiumsInOut"]["value"])
+        else:
+            return Wad(0)
+
     def get_policy(self, policy_id):
         policy_data = self.contract.getPolicy(policy_id)
         if policy_data:
@@ -719,6 +728,8 @@ class PolicyPool(ETHWrapper):
             return Wad(receipt.events["PoolLoanRepaid"]["value"])
         else:
             return Wad(0)
+
+    expire_policy = MethodAdapter((("policy_id", "int"), ))
 
 
 class BaseAssetManager(ETHWrapper):


### PR DESCRIPTION
`expirePolicy` is a public endpoint that can be called by anyone after
the policy expired. It resolves the policy with zero payout,
distributing the premiums and unlocking the SCR.

`withdrawWonPremiums` this endpoint is restricted to used with role
WITHDRAW_WON_PREMIUMS_ROLE and withdraws the won pure premiums to the
treasury. Can be disabled revoking the WITHDRAW_WON_PREMIUMS_ROLE.