### PR TITLE
SCR insolvency / Config and NFT take pool address

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,3 +17,4 @@ __pycache__
 build/
 reports/
 trash/
+data/

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ __pycache__
 build/
 reports/
 trash/
+data/

--- a/contracts/AaveAssetManager.sol
+++ b/contracts/AaveAssetManager.sol
@@ -282,7 +282,7 @@ contract AaveAssetManager is BaseAssetManager {
     bool tweak = !hasPoolRole(LEVEL2_ROLE);
     require(
       !tweak || _isTweakWad(_maxSlippage, newValue, 3e26),
-      "Tweak exceeded: claimRewardsMin tweaks only up to 30%"
+      "Tweak exceeded: maxSlippage tweaks only up to 30%"
     );
     _maxSlippage = newValue;
     _parameterChanged(IPolicyPoolConfig.GovernanceActions.setMaxSlippage, newValue, tweak);

--- a/contracts/AaveAssetManager.sol
+++ b/contracts/AaveAssetManager.sol
@@ -175,6 +175,7 @@ contract AaveAssetManager is BaseAssetManager {
   }
 
   function rebalance() public virtual override whenNotPaused {
+    _claimRewards();
     super.rebalance();
     reinvestRewardToken();
   }

--- a/contracts/AaveAssetManager.sol
+++ b/contracts/AaveAssetManager.sol
@@ -254,10 +254,7 @@ contract AaveAssetManager is BaseAssetManager {
     return _maxSlippage;
   }
 
-  function setClaimRewardsMin(uint256 newValue)
-    external
-    onlyPoolRole2(LEVEL2_ROLE, LEVEL3_ROLE)
-  {
+  function setClaimRewardsMin(uint256 newValue) external onlyPoolRole2(LEVEL2_ROLE, LEVEL3_ROLE) {
     bool tweak = !hasPoolRole(LEVEL2_ROLE);
     require(
       !tweak || _isTweakWad(_claimRewardsMin, newValue, 3e26),
@@ -280,10 +277,7 @@ contract AaveAssetManager is BaseAssetManager {
     _parameterChanged(IPolicyPoolConfig.GovernanceActions.setReinvestRewardsMin, newValue, tweak);
   }
 
-  function setMaxSlippage(uint256 newValue)
-    external
-    onlyPoolRole2(LEVEL2_ROLE, LEVEL3_ROLE)
-  {
+  function setMaxSlippage(uint256 newValue) external onlyPoolRole2(LEVEL2_ROLE, LEVEL3_ROLE) {
     require(newValue <= 1e17, "maxSlippage can't be more than 10%");
     bool tweak = !hasPoolRole(LEVEL2_ROLE);
     require(
@@ -293,5 +287,4 @@ contract AaveAssetManager is BaseAssetManager {
     _maxSlippage = newValue;
     _parameterChanged(IPolicyPoolConfig.GovernanceActions.setMaxSlippage, newValue, tweak);
   }
-
 }

--- a/contracts/BaseAssetManager.sol
+++ b/contracts/BaseAssetManager.sol
@@ -69,7 +69,6 @@ abstract contract BaseAssetManager is IAssetManager, PolicyPoolComponent {
     _validateParameters();
   }
 
-  // runs validation on EToken parameters
   function _validateParameters() internal view {
     require(
       _liquidityMin <= _liquidityMiddle && _liquidityMiddle <= _liquidityMax,

--- a/contracts/DataTypes.sol
+++ b/contracts/DataTypes.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.0;
 
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import {IEToken} from "../interfaces/IEToken.sol";
-import {IRiskModule} from "../interfaces/IRiskModule.sol";
 
 library DataTypes {
   using EnumerableSet for EnumerableSet.AddressSet;

--- a/contracts/PolicyNFT.sol
+++ b/contracts/PolicyNFT.sol
@@ -13,19 +13,27 @@ contract PolicyNFT is ERC721Upgradeable, PolicyPoolComponent, IPolicyNFT {
 
   CountersUpgradeable.Counter private _tokenIdCounter;
 
-  function initialize(string memory name_, string memory symbol_) public initializer {
+  function initialize(
+    string memory name_,
+    string memory symbol_,
+    IPolicyPool policyPool_
+  ) public initializer {
     __ERC721_init(name_, symbol_);
     __PolicyPoolComponent_init(IPolicyPool(address(0)));
-    __PolicyNFT_init_unchained();
+    __PolicyNFT_init_unchained(policyPool_);
   }
 
   // solhint-disable-next-line func-name-mixedcase
-  function __PolicyNFT_init_unchained() internal initializer {
+  function __PolicyNFT_init_unchained(IPolicyPool policyPool_) internal initializer {
+    _policyPool = policyPool_;
     _tokenIdCounter.increment(); // I don't want _tokenId==0
   }
 
   function connect() external override {
-    require(address(_policyPool) == address(0), "PolicyPool already connected");
+    require(
+      address(_policyPool) == address(0) || address(_policyPool) == _msgSender(),
+      "PolicyPool already connected"
+    );
     _policyPool = IPolicyPool(_msgSender());
     // Not possible to do this validation because connect is called in _policyPool initialize :'(
     // require(_policyPool.config() == this, "PolicyPool not connected to this config");

--- a/contracts/PolicyPool.sol
+++ b/contracts/PolicyPool.sol
@@ -199,6 +199,10 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable {
     emit ETokenStatusChanged(eToken, newStatus);
   }
 
+  function getETokenStatus(IEToken eToken) external view returns (DataTypes.ETokenStatus) {
+    return _eTokens.get(eToken);
+  }
+
   function setAssetManager(IAssetManager newAssetManager) external override {
     require(msg.sender == address(_config), "Only the PolicyPoolConfig can change assetManager");
     if (address(_config.assetManager()) != address(0)) {
@@ -479,7 +483,7 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable {
       if (borrowFromScr > 0) {
         uint256 aux;
         aux = borrowFromScr.wadMul(etkScr);
-        borrowFromScrLeft += aux - etk.lendToPool(aux);
+        borrowFromScrLeft += aux - etk.lendToPool(aux, true);
       }
     }
     return borrowFromScrLeft;
@@ -521,7 +525,7 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable {
     for (uint256 i = 0; i < _eTokens.length(); i++) {
       (IEToken etk, DataTypes.ETokenStatus etkStatus) = _eTokens.at(i);
       if (etkStatus != DataTypes.ETokenStatus.active) continue;
-      loanLeft -= etk.lendToPool(loanLeft);
+      loanLeft -= etk.lendToPool(loanLeft, false);
       if (loanLeft <= NEGLIGIBLE_AMOUNT) break;
     }
     return loanLeft;

--- a/contracts/PolicyPool.sol
+++ b/contracts/PolicyPool.sol
@@ -406,7 +406,11 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable {
     return _resolvePolicy(policyId, payout, false);
   }
 
-  function resolvePolicy(uint256 policyId, bool customerWon) external override whenNotPaused {
+  function resolvePolicyFullPayout(uint256 policyId, bool customerWon)
+    external
+    override
+    whenNotPaused
+  {
     return _resolvePolicy(policyId, customerWon ? _policies[policyId].payout : 0, false);
   }
 

--- a/contracts/PolicyPoolConfig.sol
+++ b/contracts/PolicyPoolConfig.sol
@@ -60,20 +60,27 @@ contract PolicyPoolConfig is
     _;
   }
 
-  function initialize(address treasury_) public initializer {
+  function initialize(IPolicyPool policyPool_, address treasury_) public initializer {
     __AccessControl_init();
     __UUPSUpgradeable_init();
-    __PolicyPoolConfig_init_unchained(treasury_);
+    __PolicyPoolConfig_init_unchained(policyPool_, treasury_);
   }
 
   // solhint-disable-next-line func-name-mixedcase
-  function __PolicyPoolConfig_init_unchained(address treasury_) internal initializer {
+  function __PolicyPoolConfig_init_unchained(IPolicyPool policyPool_, address treasury_)
+    internal
+    initializer
+  {
     _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
+    _policyPool = policyPool_;
     _treasury = treasury_;
   }
 
   function connect() external override {
-    require(address(_policyPool) == address(0), "PolicyPool already connected");
+    require(
+      address(_policyPool) == address(0) || address(_policyPool) == _msgSender(),
+      "PolicyPool already connected"
+    );
     _policyPool = IPolicyPool(_msgSender());
     // Not possible to do this validation because connect is called in _policyPool initialize :'(
     // require(_policyPool.config() == this, "PolicyPool not connected to this config");

--- a/contracts/TrustfulRiskModule.sol
+++ b/contracts/TrustfulRiskModule.sol
@@ -70,11 +70,11 @@ contract TrustfulRiskModule is RiskModule {
     return _policyPool.resolvePolicy(policyId, payout);
   }
 
-  function resolvePolicy(uint256 policyId, bool customerWon)
+  function resolvePolicyFullPayout(uint256 policyId, bool customerWon)
     external
     onlyRole(RESOLVER_ROLE)
     whenNotPaused
   {
-    return _policyPool.resolvePolicy(policyId, customerWon);
+    return _policyPool.resolvePolicyFullPayout(policyId, customerWon);
   }
 }

--- a/contracts/mocks/FreeGrantInsolvencyHook.sol
+++ b/contracts/mocks/FreeGrantInsolvencyHook.sol
@@ -6,6 +6,7 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 import {IPolicyPool} from "../../interfaces/IPolicyPool.sol";
 import {IPolicyPoolComponent} from "../../interfaces/IPolicyPoolComponent.sol";
 import {IInsolvencyHook} from "../../interfaces/IInsolvencyHook.sol";
+import {IEToken} from "../../interfaces/IEToken.sol";
 import {WadRayMath} from "../WadRayMath.sol";
 import {IMintableERC20} from "./IMintableERC20.sol";
 
@@ -39,4 +40,7 @@ contract FreeGrantInsolvencyHook is IInsolvencyHook, IPolicyPoolComponent {
     cashGranted += paymentAmount;
     emit OutOfCashGranted(paymentAmount);
   }
+
+  // solhint-disable-next-line no-empty-blocks
+  function insolventEToken(IEToken eToken, uint256 paymentAmount) external override {}
 }

--- a/contracts/mocks/PolicyPoolMock.sol
+++ b/contracts/mocks/PolicyPoolMock.sol
@@ -106,7 +106,7 @@ contract PolicyPoolMock is IPolicyPool {
     _resolvePolicy(policyId, payout);
   }
 
-  function resolvePolicy(uint256 policyId, bool customerWon) external override {
+  function resolvePolicyFullPayout(uint256 policyId, bool customerWon) external override {
     return _resolvePolicy(policyId, customerWon ? policies[policyId].payout : 0);
   }
 

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -58,6 +58,9 @@ module.exports = {
     localhost: {
       url: "http://127.0.0.1:8545"
     },
+    ganache: {
+      url: "http://ganache-cli:8545"
+    },
     hardhat: {
     },
     bsctestnet: {

--- a/interfaces/IEToken.sol
+++ b/interfaces/IEToken.sol
@@ -34,7 +34,7 @@ interface IEToken is IERC20 {
 
   function accepts(uint40 policyExpiration) external view returns (bool);
 
-  function lendToPool(uint256 amount) external returns (uint256);
+  function lendToPool(uint256 amount, bool fromOcean) external returns (uint256);
 
   function repayPoolLoan(uint256 amount) external;
 

--- a/interfaces/IInsolvencyHook.sol
+++ b/interfaces/IInsolvencyHook.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
+import {IEToken} from "./IEToken.sol";
+
 /**
  * @title IInsolvencyHook interface
  * @dev Interface for insolvency hook, the contract that manages the insolvency situation of the pool
@@ -14,4 +16,12 @@ interface IInsolvencyHook {
    * @param paymentAmount The amount of the payment
    */
   function outOfCash(uint256 paymentAmount) external;
+
+  /**
+   * @dev This is called from EToken when doesn't have enought totalSupply to cover the SCR
+   *      The hook might choose not to do anything or solve the insolvency with a deposit
+   * @param eToken The token that suffers insolvency
+   * @param paymentAmount The amount of the payment
+   */
+  function insolventEToken(IEToken eToken, uint256 paymentAmount) external;
 }

--- a/interfaces/IPolicyPool.sol
+++ b/interfaces/IPolicyPool.sol
@@ -18,7 +18,7 @@ interface IPolicyPool {
 
   function resolvePolicy(uint256 policyId, uint256 payout) external;
 
-  function resolvePolicy(uint256 policyId, bool customerWon) external;
+  function resolvePolicyFullPayout(uint256 policyId, bool customerWon) external;
 
   function receiveGrant(uint256 amount) external;
 

--- a/interfaces/IPolicyPoolConfig.sol
+++ b/interfaces/IPolicyPoolConfig.sol
@@ -39,6 +39,10 @@ interface IPolicyPoolConfig is IAccessControlUpgradeable {
     setLiquidityMin,
     setLiquidityMiddle,
     setLiquidityMax,
+    // AaveAssetManager Governance Actions
+    setClaimRewardsMin,
+    setReinvestRewardsMin,
+    setMaxSlippage,
     last
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1391,14 +1391,14 @@
       }
     },
     "@openzeppelin/contracts": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.2.0.tgz",
-      "integrity": "sha512-LD4NnkKpHHSMo5z9MvFsG4g1xxZUDqV3A3Futu3nvyfs4wPwXxqOgMaxOoa2PeyGL2VNeSlbxT54enbQzGcgJQ=="
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.3.2.tgz",
+      "integrity": "sha512-AybF1cesONZStg5kWf6ao9OlqTZuPqddvprc0ky7lrUVOjXeKpmQ2Y9FK+6ygxasb+4aic4O5pneFBfwVsRRRg=="
     },
     "@openzeppelin/contracts-upgradeable": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.2.0.tgz",
-      "integrity": "sha512-vn0hoUqQzgOLzLZwFgh+w/D5hzJHX8F7X/7t/gZdSQYIEXMyGpXUwkr5A3eoAeoc42f/n7yDhwusvBmNknM41Q=="
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.3.2.tgz",
+      "integrity": "sha512-i/pOaOtcqDk4UqsrOv735uYyTbn6dvfiuVu5hstsgV6c4ZKUtu88/31zT2BzkCg+3JfcwOfgg2TtRKVKKZIGkQ=="
     },
     "@openzeppelin/hardhat-upgrades": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   },
   "dependencies": {
     "@aave/protocol-v2": "git+https://github.com/gnarvaja/protocol-v2.git",
-    "@openzeppelin/contracts": "^4.2.0",
-    "@openzeppelin/contracts-upgradeable": "^4.2.0",
+    "@openzeppelin/contracts": "^4.3.2",
+    "@openzeppelin/contracts-upgradeable": "^4.3.2",
     "@uniswap/v2-periphery": "^1.1.0-beta.0"
   }
 }

--- a/prototype/utils.py
+++ b/prototype/utils.py
@@ -112,6 +112,13 @@ def load_config(yaml_config=None, module=None):
         asset_manager = getattr(module, asset_manager_class)(**asset_manager)
         pool.config.set_asset_manager(asset_manager)
 
+    insolvency_hook = config.get("insolvency_hook", {})
+    if insolvency_hook:
+        insolvency_hook_class = insolvency_hook.pop("class")
+        insolvency_hook["pool"] = pool
+        insolvency_hook = getattr(module, insolvency_hook_class)(**insolvency_hook)
+        pool.config.set_insolvency_hook(insolvency_hook)
+
     return pool
 
 

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -61,8 +61,6 @@ async function deployPolicyPoolConfig({verify, treasuryAddress}, hre) {
   const PolicyPoolConfig = await hre.ethers.getContractFactory("PolicyPoolConfig");
   const policyPoolConfig = await hre.upgrades.deployProxy(PolicyPoolConfig, [
     treasuryAddress,
-    hre.ethers.constants.AddressZero,
-    hre.ethers.constants.AddressZero,
   ], {kind: 'uups'});
 
   await policyPoolConfig.deployed();

--- a/tests/test_aave_assetmanager.py
+++ b/tests/test_aave_assetmanager.py
@@ -109,7 +109,7 @@ def skip_if_not_fork(f):
 
 # @pytest.mark.require_network("polygon-main-fork") - DOES NOT WORK
 @skip_if_not_fork
-def test_get_balance(USDC, aave, PolicyPoolAndConfig, WMATIC):
+def test_aave_asset_manager(USDC, aave, PolicyPoolAndConfig, WMATIC):
     AAVE_address = "0x1a13f4ca1d028320a707d99520abfefca3998b7f"
     assert int(USDC.balance_of(AAVE_address)) > (1000000 * 10**6)  # At least 1 millon if in the right fork
 

--- a/tests/test_aave_assetmanager.py
+++ b/tests/test_aave_assetmanager.py
@@ -132,7 +132,8 @@ def test_aave_asset_manager(USDC, aave, PolicyPoolAndConfig, WMATIC):
         liquidity_middle=liquidity_middle,
         liquidity_max=liquidity_max,
         aave_address_provider=AAVE_AP_ADDRESS,
-        swap_router=SUSHISWAP_ROUTER_ADDRESS
+        swap_router=SUSHISWAP_ROUTER_ADDRESS,
+        max_slippage=_W("0.01")
     )
 
     # Donate 2 matic to aave_mgr

--- a/tests/test_aave_assetmanager.py
+++ b/tests/test_aave_assetmanager.py
@@ -110,6 +110,8 @@ def skip_if_not_fork(f):
 # @pytest.mark.require_network("polygon-main-fork") - DOES NOT WORK
 @skip_if_not_fork
 def test_aave_asset_manager(USDC, aave, PolicyPoolAndConfig, WMATIC):
+    # This test is not determinist and sometimes gives false negatives. Run manually and
+    # if fails try again or understand the results
     AAVE_address = "0x1a13f4ca1d028320a707d99520abfefca3998b7f"
     assert int(USDC.balance_of(AAVE_address)) > (1000000 * 10**6)  # At least 1 millon if in the right fork
 
@@ -133,7 +135,7 @@ def test_aave_asset_manager(USDC, aave, PolicyPoolAndConfig, WMATIC):
         liquidity_max=liquidity_max,
         aave_address_provider=AAVE_AP_ADDRESS,
         swap_router=SUSHISWAP_ROUTER_ADDRESS,
-        max_slippage=_W("0.01")
+        max_slippage=_W("0.0")
     )
 
     # Donate 2 matic to aave_mgr
@@ -144,6 +146,7 @@ def test_aave_asset_manager(USDC, aave, PolicyPoolAndConfig, WMATIC):
     aave_mgr.get_investment_value().assert_equal(_W(2) * usd_per_matic // _W(10**12))
 
     config.grant_role("LEVEL1_ROLE", config.owner)
+    config.grant_role("LEVEL2_ROLE", "WHOKNOWSWHENTOSELL")
     config.set_asset_manager(aave_mgr)
 
     # Transfer LP1 USD to PolicyPoolMockForward
@@ -163,8 +166,18 @@ def test_aave_asset_manager(USDC, aave, PolicyPoolAndConfig, WMATIC):
 
     config.grant_role("SWAP_REWARDS_ROLE", "WHOKNOWSWHENTOSELL")
 
+    # with aave_mgr.as_("WHOKNOWSWHENTOSELL"), pytest.raises(
+    #        RevertError, match="UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT"):
+    #    wmatic_in, usdc_out = aave_mgr.swap_rewards(_W(3))  # Fails because max_slippage=0
+    # Sometimes fails, others don't. It depends on the difference between Sushi and Chainlink price
+
     with aave_mgr.as_("WHOKNOWSWHENTOSELL"):
-        wmatic_in, usdc_out = aave_mgr.swap_rewards(_W(3))
+        aave_mgr.max_slippage = _W("0.02")
+
+    assert aave_mgr.max_slippage == _W("0.02")
+
+    with aave_mgr.as_("WHOKNOWSWHENTOSELL"):
+        wmatic_in, usdc_out = aave_mgr.swap_rewards(_W(3))  # Fails because max_slippage=0
 
     wmatic_in.assert_equal(_W(2))
     usdc_out.assert_equal(_W(2) * usd_per_matic // _W(10**12))
@@ -193,4 +206,4 @@ def test_aave_asset_manager(USDC, aave, PolicyPoolAndConfig, WMATIC):
     # No funds in aave_mgr
     aave_mgr.aToken.balance_of(aave_mgr).assert_equal(_W(0))
     WMATIC.balance_of(aave_mgr).assert_equal(_W(0))
-    aave_mgr.rewardAToken.balance_of(aave_mgr).assert_equal(_W(0))
+    aave_mgr.rewardAToken.balance_of(aave_mgr).assert_equal(_W(0), decimals=2)

--- a/tests/wrappers.py
+++ b/tests/wrappers.py
@@ -571,16 +571,14 @@ class TrustfulRiskModule(RiskModuleETH):
         ("customer", "address")
     ), "int")
 
-    resolve_policy_bool = MethodAdapter((("policy_id", "int"), ("customer_won", "bool")),
-                                        eth_variant="uint,bool", eth_method="resolvePolicy")
-    resolve_policy_amount = MethodAdapter((("policy_id", "int"), ("payout", "amount")),
-                                          eth_variant="uint,uint", eth_method="resolvePolicy")
+    resolve_policy_full_payout = MethodAdapter((("policy_id", "int"), ("customer_won", "bool")))
+    resolve_policy_ = MethodAdapter((("policy_id", "int"), ("payout", "amount")))
 
     def resolve_policy(self, policy_id, customer_won_or_amount):
         if customer_won_or_amount is True or customer_won_or_amount is False:
-            return self.resolve_policy_bool(policy_id,  customer_won_or_amount)
+            return self.resolve_policy_full_payout(policy_id,  customer_won_or_amount)
         else:
-            return self.resolve_policy_amount(policy_id,  customer_won_or_amount)
+            return self.resolve_policy_(policy_id,  customer_won_or_amount)
 
     def new_policy(self, *args, **kwargs):
         receipt = self.new_policy_(*args, **kwargs)

--- a/tests/wrappers.py
+++ b/tests/wrappers.py
@@ -837,6 +837,10 @@ class AaveAssetManager(BaseAssetManager):
         else:
             return Wad(0)
 
+    max_slippage = MethodAdapter((), "amount", is_property=True)
+    claim_rewards_min = MethodAdapter((), "amount", is_property=True)
+    reinvest_rewards_min = MethodAdapter((), "amount", is_property=True)
+
 
 class FreeGrantInsolvencyHook(ETHWrapper):
     eth_contract = "FreeGrantInsolvencyHook"

--- a/tests/wrappers.py
+++ b/tests/wrappers.py
@@ -365,7 +365,7 @@ class PolicyNFT(IERC721):
     proxy_kind = "uups"
 
     def __init__(self, owner="Owner", name="Test NFT", symbol="NFTEST"):
-        super().__init__(owner, name, symbol)
+        super().__init__(owner, name, symbol, AddressBook.ZERO)
 
 
 def _adapt_signed_amount(args, kwargs):
@@ -599,7 +599,7 @@ class PolicyPoolConfig(ETHWrapper):
 
     def __init__(self, owner, treasury="ENS"):
         treasury = self._get_account(treasury)
-        super().__init__(owner, treasury)
+        super().__init__(owner, AddressBook.ZERO, treasury)
         self._auto_from = self.owner
         self.risk_modules = {}
 
@@ -684,7 +684,7 @@ class PolicyPool(ETHWrapper):
     won_pure_premiums = MethodAdapter((), "amount", is_property=True)
     active_premiums = MethodAdapter((), "amount", is_property=True)
     active_pure_premiums = MethodAdapter((), "amount", is_property=True)
-    borrowed_active_pp = MethodAdapter((), "amount", is_property=True)
+    borrowed_active_pp = MethodAdapter((), "amount", is_property=True, eth_method="borrowedActivePP")
     add_etoken_ = MethodAdapter((("etoken", "contract"), ), eth_method="addEToken")
 
     def add_etoken(self, etoken):
@@ -848,9 +848,9 @@ class FreeGrantInsolvencyHook(ETHWrapper):
 class LPInsolvencyHook(ETHWrapper):
     eth_contract = "LPInsolvencyHook"
 
-    def __init__(self, pool, etoken):
+    def __init__(self, pool, etoken, cover_etoken=False):
         etoken = pool.etokens[etoken]
-        super().__init__("owner", pool.contract, etoken.contract)
+        super().__init__("owner", pool.contract, etoken.contract, cover_etoken)
 
     cash_deposited = MethodAdapter((), "amount", is_property=True)
 

--- a/tests/wrappers.py
+++ b/tests/wrappers.py
@@ -805,10 +805,10 @@ class AaveAssetManager(BaseAssetManager):
 
     def __init__(self, owner, pool, liquidity_min, liquidity_middle, liquidity_max,
                  aave_address_provider, swap_router, claim_rewards_min=_W(0),
-                 reinvest_rewards_min=_W(0)):
+                 reinvest_rewards_min=_W(0), max_slippage=_W("0.01")):
         super().__init__(
             owner, pool, liquidity_min, liquidity_middle, liquidity_max, aave_address_provider,
-            swap_router, claim_rewards_min, reinvest_rewards_min
+            swap_router, claim_rewards_min, reinvest_rewards_min, max_slippage
         )
 
     @property

--- a/tests/wrappers.py
+++ b/tests/wrappers.py
@@ -460,10 +460,10 @@ class ETokenETH(IERC20):
         adapt_args=lambda args, kwargs: ((args[0].expiration, ), {})
     )
 
-    lend_to_pool_ = MethodAdapter((("amount", "amount"), ))
+    lend_to_pool_ = MethodAdapter((("amount", "amount"), ("from_ocean", "bool")))
 
-    def lend_to_pool(self, amount):
-        receipt = self.lend_to_pool_(amount)
+    def lend_to_pool(self, amount, from_ocean=True):
+        receipt = self.lend_to_pool_(amount, from_ocean)
         if "PoolLoan" in receipt.events:
             return Wad(receipt.events["PoolLoan"]["value"])
         else:
@@ -804,9 +804,11 @@ class AaveAssetManager(BaseAssetManager):
     eth_contract = "AaveAssetManager"
 
     def __init__(self, owner, pool, liquidity_min, liquidity_middle, liquidity_max,
-                 aave_address_provider, swap_router):
+                 aave_address_provider, swap_router, claim_rewards_min=_W(0),
+                 reinvest_rewards_min=_W(0)):
         super().__init__(
-            owner, pool, liquidity_min, liquidity_middle, liquidity_max, aave_address_provider, swap_router
+            owner, pool, liquidity_min, liquidity_middle, liquidity_max, aave_address_provider,
+            swap_router, claim_rewards_min, reinvest_rewards_min
         )
 
     @property


### PR DESCRIPTION
Previously, lendToPool was only considering the ocean, leaving always
the SCR. Now, was a parameter to consider all the total supply. This can
lead to a situation where `SCR>totalSupply`, in those cases, we call the
InsolvencyHook to give the opportunity to solve this lack of SCR.

Other change, now PolicyPoolConfig and PolicyNFT accept the address of
the PolicyPool in the initialization. This allows pre-calculate the
address of PolicyPool (with CREATE2) and create PolicyPoolConfig and
PolicyNFT with that address already connected.