### PR TITLE
Forbid paid resolution of expired policies

### DIFF
--- a/contracts/EToken.sol
+++ b/contracts/EToken.sol
@@ -496,7 +496,7 @@ contract EToken is PolicyPoolComponent, IERC20Metadata, IEToken {
   }
 
   function utilizationRate() public view returns (uint256) {
-    return _scr.wadDiv(this.totalSupply()).rayToWad();
+    return _scr.wadDiv(this.totalSupply()).wadToRay();
   }
 
   function lockScr(uint256 policyInterestRate, uint256 scrAmount) external override onlyPolicyPool {

--- a/contracts/EToken.sol
+++ b/contracts/EToken.sol
@@ -495,6 +495,10 @@ contract EToken is PolicyPoolComponent, IERC20Metadata, IEToken {
     return _maxUtilizationRate;
   }
 
+  function utilizationRate() public view returns (uint256) {
+    return _scr.wadDiv(this.totalSupply()).rayToWad();
+  }
+
   function lockScr(uint256 policyInterestRate, uint256 scrAmount) external override onlyPolicyPool {
     require(scrAmount <= this.ocean(), "Not enought OCEAN to cover the SCR");
     _updateCurrentScale();

--- a/contracts/PolicyPool.sol
+++ b/contracts/PolicyPool.sol
@@ -430,8 +430,9 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable {
     require(policy.id == policyId && policyId != 0, "Policy not found");
     IRiskModule rm = policy.riskModule;
     require(expired || address(rm) == msg.sender, "Only the RM can resolve policies");
+    require(payout == 0 || policy.expiration > block.timestamp, "Can't pay expired policy");
     _config.checkAcceptsResolvePolicy(rm);
-    require(payout <= policy.payout, "Actual payout can't be more than policy payout");
+    require(payout <= policy.payout, "payout > policy.payout");
 
     bool customerWon = payout > 0;
 

--- a/prototype/ensuro.py
+++ b/prototype/ensuro.py
@@ -682,6 +682,8 @@ class PolicyPool(AccessControlContract):
 
         customer_won = payout > Wad(0)
 
+        require(payout == 0 or policy.expiration > time_control.now, "Can't pay expired policy")
+
         self.active_premiums -= policy.premium
         self.active_pure_premiums -= policy.pure_premium
 

--- a/prototype/ensuro.py
+++ b/prototype/ensuro.py
@@ -452,6 +452,10 @@ class EToken(ERC20Token):
     def set_max_utilization_rate(self, new_rate):
         self.max_utilization_rate = new_rate
 
+    @property
+    def utilization_rate(self):
+        return (self.scr // self.total_supply()).to_ray()
+
     def get_investable(self):
         return self.scr + self.ocean + self.get_pool_loan()
 

--- a/prototype/wrappers.py
+++ b/prototype/wrappers.py
@@ -77,6 +77,7 @@ class EToken(IERC20):
         pool_loan_interest_rate = _R(pool_loan_interest_rate)
         liquidity_requirement = _R(liquidity_requirement)
         max_utilization_rate = _R(max_utilization_rate)
+        
         super().__init__(
             owner, policy_pool,
             name, symbol, expiration_period, liquidity_requirement,
@@ -106,6 +107,7 @@ class EToken(IERC20):
     pool_loan_interest_rate = MethodAdapter((), "ray", is_property=True)
     liquidity_requirement = MethodAdapter((), "ray", is_property=True)
     max_utilization_rate = MethodAdapter((), "ray", is_property=True)
+    utilization_rate = MethodAdapter((), "ray", is_property=True)
     set_pool_loan_interest_rate = MethodAdapter((("new_rate", "ray"), ))
     set_max_utilization_rate = MethodAdapter((("new_rate", "ray"), ))
 

--- a/tests/test_etoken.py
+++ b/tests/test_etoken.py
@@ -437,6 +437,44 @@ def test_max_utilization_rate(tenv):
 
     assert etk.ocean_for_new_scr == _W(950)
 
+    policy = tenv.policy_factory(scr=_W(1100), interest_rate=_R("0.04"),
+                                expiration=tenv.time_control.now + WEEK)
+                                
+    with pytest.raises(RevertError, match="Not enought OCEAN to cover the SCR"):
+        with etk.thru_policy_pool():
+            etk.lock_scr(policy, policy.scr)
+
+    with etk.thru_policy_pool():
+        etk.deposit("LP1", _W(1000))
+
+    policy = tenv.policy_factory(scr=_W(600), interest_rate=_R("0.0365"),
+                                 expiration=tenv.time_control.now + WEEK)
+    with etk.thru_policy_pool():
+        etk.lock_scr(policy, policy.scr)
+
+
+def test_unlock_scr(tenv):
+    etk = tenv.etoken_class(name="eUSD1WEEK", expiration_period=WEEK)
+    with etk.thru_policy_pool():
+        assert etk.deposit("LP1", _W(1000)) == _W(1000)
+    assert etk.ocean == _W(1000)
+    policy = tenv.policy_factory(scr=_W(600), interest_rate=_R("0.0365"),
+                                 expiration=tenv.time_control.now + WEEK)
+    with etk.thru_policy_pool():
+        etk.lock_scr(policy, policy.scr)
+    assert etk.scr == _W(600)
+    assert etk.scr_interest_rate == _R("0.0365")
+    etk.token_interest_rate.assert_equal(_R("0.0365") * _R(600/1000))
+    etk.ocean.assert_equal(_W(400))
+
+    tenv.time_control.fast_forward(2 * DAY)
+    etk.balance_of("LP1").assert_equal(_W(1000) + _W("0.06") * _W(2))
+    tenv.time_control.fast_forward(3 * DAY)
+    etk.balance_of("LP1").assert_equal(_W(1000) + _W("0.06") * _W(5))
+
+    with etk.thru_policy_pool():
+        etk.unlock_scr(policy, policy.scr)
+
 
 def test_getset_etk_parameters_tweaks(tenv):
     if tenv.kind != "ethereum":

--- a/tests/test_etoken.py
+++ b/tests/test_etoken.py
@@ -444,13 +444,21 @@ def test_max_utilization_rate(tenv):
         with etk.thru_policy_pool():
             etk.lock_scr(policy, policy.scr)
 
-    with etk.thru_policy_pool():
-        etk.deposit("LP1", _W(1000))
-
     policy = tenv.policy_factory(scr=_W(600), interest_rate=_R("0.0365"),
                                  expiration=tenv.time_control.now + WEEK)
     with etk.thru_policy_pool():
         etk.lock_scr(policy, policy.scr)
+
+    etk.utilization_rate.assert_equal(_R("0.6"))
+    with etk.thru_policy_pool():
+        etk.deposit("LP1", _W(1000))
+    
+    etk.utilization_rate.assert_equal(_R("0.3"))
+
+    expected_balance = _W(2000) - _W("600") * _W("1.0365")
+    with etk.thru_policy_pool():
+        etk.withdraw("LP1", _W(1400)).assert_equal(expected_balance)
+
 
 
 def test_unlock_scr(tenv):

--- a/tests/test_policypool.py
+++ b/tests/test_policypool.py
@@ -5,7 +5,7 @@ import pytest
 from ethproto.contracts import RevertError
 from ethproto.wadray import _W, _R, set_precision, Wad
 from ethproto.wrappers import get_provider
-from prototype.utils import load_config, WEEK, DAY
+from prototype.utils import load_config, WEEK, DAY, HOUR
 from . import extract_vars, is_brownie_coverage_enabled
 
 TEnv = namedtuple("TEnv", "time_control module kind")
@@ -90,11 +90,11 @@ def test_transfers(tenv):
     etoken.balance_of("LP2").assert_equal(lp1_balance // _W(3))
     etoken.balance_of("LP3").assert_equal(lp1_balance // _W(3))
 
-    timecontrol.fast_forward(4 * DAY)
+    timecontrol.fast_forward(2 * DAY)
 
-    etoken.balance_of("LP1").assert_equal(lp1_balance // _W(3) + interest * _W(4/7) // _W(3))
-    etoken.balance_of("LP2").assert_equal(lp1_balance // _W(3) + interest * _W(4/7) // _W(3))
-    etoken.balance_of("LP3").assert_equal(lp1_balance // _W(3) + interest * _W(4/7) // _W(3))
+    etoken.balance_of("LP1").assert_equal(lp1_balance // _W(3) + interest * _W(2/7) // _W(3))
+    etoken.balance_of("LP2").assert_equal(lp1_balance // _W(3) + interest * _W(2/7) // _W(3))
+    etoken.balance_of("LP3").assert_equal(lp1_balance // _W(3) + interest * _W(2/7) // _W(3))
 
     rm.resolve_policy(policy.id, True)
     etoken.balance_of("LP1").assert_equal(_W(0))
@@ -659,7 +659,7 @@ def test_walkthrough(tenv):
         )
         customer_won = day % 37 == 36
         for p in list(policies):
-            if p.expiration > timecontrol.now:
+            if p.expiration > (timecontrol.now + DAY):
                 break
             if customer_won:
                 won_count += 1
@@ -706,31 +706,31 @@ def test_walkthrough(tenv):
         pool_loan = eUSD1YEAR.get_pool_loan()
 
     assert eUSD1YEAR.get_pool_loan() == _W(0)
-    assert pool.pure_premiums.equal(_W("21.21943222506249692"))  # from jypiter prints
+    pool.pure_premiums.assert_equal(_W("21.21943222506249692"), decimals=2)  # from jypiter prints
 
     assert USD.balance_of(pool.contract_id).equal(
         _W(1000 + 2000 + 2 - 35 + 2 * 65 - 72 * won_count) +
-        _W(2000) - _W("1977.98534")
+        _W(2000) - _W("1977.98534"), decimals=2
     )
 
     pool.withdraw("eUSD1YEAR", "LP1", None).assert_equal(
-        _W("1023.42788568762743449")
+        _W("1023.42788568762743449"), decimals=2
     )
     pool.withdraw("eUSD1WEEK", "LP3", None).assert_equal(
-        _W("500.587288338126130735")
+        _W("500.587288338126130735"), decimals=2
     )
     pool.withdraw("eUSD1MONTH", "LP3", None).assert_equal(
-        _W("1501.780045569056425935")
+        _W("1501.780045569056425935"), decimals=2
     )
     USD.balance_of(pool.contract_id).assert_equal(
-        _W("21.219432")
+        _W("21.219432"), decimals=2
     )
 
     USD.balance_of("LP1").assert_equal(
-        _W("1023.42788568762743449")
+        _W("1023.42788568762743449"), decimals=2
     )
     USD.balance_of("LP3").assert_equal(
-        _W("500.587288338126130735") + _W("1501.780045569056425935")
+        _W("500.587288338126130735") + _W("1501.780045569056425935"), decimals=2
     )
     USD.balance_of("CUST3").assert_equal(_W(72))
 
@@ -786,7 +786,7 @@ def test_nfts(tenv):
 
     nft.transfer_from("CUST1", "CUST1", "CUST2", policy.id)
 
-    timecontrol.fast_forward(WEEK)
+    timecontrol.fast_forward(WEEK - DAY)
     rm.resolve_policy(policy.id, True)
     assert usd.balance_of("CUST1") == _W(0)
     assert usd.balance_of("CUST2") == _W(3600)
@@ -839,7 +839,7 @@ def test_partial_payout(tenv):
 
     assert pool.etokens["eUSD1YEAR"].ocean == _W(700)
     assert pool.etokens["eUSD1YEAR"].scr == _W(2800)
-    timecontrol.fast_forward(WEEK)
+    timecontrol.fast_forward(WEEK - HOUR)
     rm.resolve_policy(policy.id, _W(1900))
     assert usd.balance_of("CUST1") == _W(1900)
     pool.etokens["eUSD1YEAR"].ocean.assert_equal(_W(1700))
@@ -908,7 +908,7 @@ def test_partial_payout_shared_coverage(tenv):
 
     assert pool.etokens["eUSD1YEAR"].ocean == _W(500)
     assert pool.etokens["eUSD1YEAR"].scr == _W(3000)
-    timecontrol.fast_forward(WEEK)
+    timecontrol.fast_forward(WEEK - HOUR)
 
     rm.resolve_policy(policy.id, _W(3000))
     assert usd.balance_of("CUST1") == _W(3000)
@@ -1010,16 +1010,18 @@ def test_asset_manager(tenv):
     pool.get_investable().assert_equal(_W(200))
     etk.get_investable().assert_equal(lp1_balance)
 
-    timecontrol.fast_forward(365 * DAY // 2)
+    timecontrol.fast_forward(365 * DAY // 2 - 60)
     pool.get_investable().assert_equal(_W(200))
-    etk.get_investable().assert_equal(lp1_balance + for_lps)
+    etk.get_investable().assert_equal(lp1_balance + for_lps, decimals=2)
 
     pool_share = _W(200) // asset_manager.total_investable()
     etk_share = etk.get_investable() // asset_manager.total_investable()
     asset_manager.checkpoint()
 
     pool.won_pure_premiums.assert_equal(_W(8500) * _W("0.025") * pool_share)
-    etk.balance_of("LP1").assert_equal(lp1_balance + for_lps + _W(8500) * _W("0.025") * etk_share)
+    etk.balance_of("LP1").assert_equal(
+        lp1_balance + for_lps + _W(8500) * _W("0.025") * etk_share, decimals=2
+    )
 
     rm.resolve_policy(policy.id, True)
     assert USD.balance_of(pool.contract_id) == _W(1500)  # balance back to middle
@@ -1087,7 +1089,7 @@ def test_insolvency_without_hook(tenv):
 
     assert USD.balance_of(pool.contract_id) == _W(1000 + 200)
 
-    timecontrol.fast_forward(365 * DAY // 2)
+    timecontrol.fast_forward(365 * DAY // 2 - 60)
 
     with pytest.raises(RevertError, match="ERC20: transfer amount exceeds balance"):
         rm.resolve_policy(policy.id, True)
@@ -1117,7 +1119,7 @@ def test_lp_insolvency_hook(tenv):
     ins_hook.cash_deposited.assert_equal(_W(8000))
     etk.ocean.assert_equal(_W(0))
     etk.scr.assert_equal(_W(0))
-    etk.get_pool_loan().assert_equal(_W(9000) + for_lps)
+    etk.get_pool_loan().assert_equal(_W(9000) + for_lps, decimals=2)
 
     etk.balance_of("LP1").assert_equal(_W(0))
     etk.balance_of(ins_hook).assert_equal(_W(0))
@@ -1140,7 +1142,7 @@ def test_lp_insolvency_hook_negative_ocean(tenv):
     ins_hook = tenv.module.LPInsolvencyHook(pool=pool, etoken="eUSD1YEAR")
     pool.config.set_insolvency_hook(ins_hook)
 
-    etk.total_supply().assert_equal(_W(1000) + for_lps)
+    etk.total_supply().assert_equal(_W(1000) + for_lps, decimals=2)
 
     USD.approve("LP3", pool.contract_id, _W(8000))
     pool.deposit("eUSD1YEAR", "LP3", _W(8000)).assert_equal(_W(8000))
@@ -1184,7 +1186,7 @@ def test_lp_insolvency_hook_cover_etoken(tenv):
     ins_hook = tenv.module.LPInsolvencyHook(pool=pool, etoken="eUSD1YEAR", cover_etoken=1)
     pool.config.set_insolvency_hook(ins_hook)
 
-    etk.total_supply().assert_equal(_W(1000) + for_lps)
+    etk.total_supply().assert_equal(_W(1000) + for_lps, decimals=2)
 
     USD.approve("LP3", pool.contract_id, _W(8000))
     pool.deposit("eUSD1YEAR", "LP3", _W(8000)).assert_equal(_W(8000))


### PR DESCRIPTION
Rejects resolution with payout>0 if the policy has expired.

Also I had to fix many test cases because they were doing exactly that,
resolving with payout after (a few seconds usually) the expiration.