### PR TITLE
Remove Shared Coverage feature

### DIFF
--- a/contracts/FlightDelayRiskModule.sol
+++ b/contracts/FlightDelayRiskModule.sol
@@ -54,7 +54,6 @@ contract FlightDelayRiskModule is RiskModule, ChainlinkClientUpgradeable {
    * @param maxScrPerPolicy_ Max SCR to be allocated to this module (in wad)
    * @param scrLimit_ Max SCR to be allocated to this module (in wad)
    * @param wallet_ Address of the RiskModule provider
-   * @param sharedCoverageMinPercentage_ minimal % of SCR that must be covered by the RM
    * @param linkToken_ Address of ChainLink LINK token
    * @param oracleParams_ Parameters of the Oracle
    */
@@ -66,7 +65,6 @@ contract FlightDelayRiskModule is RiskModule, ChainlinkClientUpgradeable {
     uint256 maxScrPerPolicy_,
     uint256 scrLimit_,
     address wallet_,
-    uint256 sharedCoverageMinPercentage_,
     address linkToken_,
     OracleParams memory oracleParams_
   ) public initializer {
@@ -77,8 +75,7 @@ contract FlightDelayRiskModule is RiskModule, ChainlinkClientUpgradeable {
       scrInterestRate_,
       maxScrPerPolicy_,
       scrLimit_,
-      wallet_,
-      sharedCoverageMinPercentage_
+      wallet_
     );
     __ChainlinkClient_init();
     __FlightDelayRiskModule_init_unchained(linkToken_, oracleParams_);

--- a/contracts/Policy.sol
+++ b/contracts/Policy.sol
@@ -81,9 +81,10 @@ library Policy {
     view
     returns (uint256 toBePaidWithPool, uint256 premiumsWon)
   {
-    uint256 nonCapitalPremiums = policy.purePremium + policy.premiumForRm + policy.premiumForEnsuro;
+    uint256 nonCapitalPremiums = policy.premium - policy.premiumForLps;
     if (nonCapitalPremiums >= payout) {
-      return (0, nonCapitalPremiums - payout); // paid with premiums and accrue the rest
+      // paid with premiums and accrue the rest even when it's premiumForEnsuro and premiumForRm
+      return (0, nonCapitalPremiums - payout);
     } else {
       return (payout - nonCapitalPremiums, 0); // pay from pool all except nonCapitalPremiums
     }

--- a/contracts/PolicyPool.sol
+++ b/contracts/PolicyPool.sol
@@ -267,7 +267,6 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable {
     uint256 policyId = _policyNFT.safeMint(customer);
     Policy.PolicyData storage policy = _policies[policyId] = policy_;
     policy.id = policyId;
-    if (policy.rmScr() > 0) _currency.safeTransferFrom(rm.wallet(), address(this), policy.rmScr());
     _activePurePremiums += policy.purePremium;
     _activePremiums += policy.premium;
     _lockScr(policy);
@@ -383,13 +382,11 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable {
 
     if (customerWon) {
       _transferTo(_policyNFT.ownerOf(policy.id), payout);
-      uint256 returnToRm;
-      (aux, purePremiumWon, returnToRm) = policy.splitPayout(payout);
-      if (returnToRm > 0) _transferTo(policy.riskModule.wallet(), returnToRm);
+      (aux, purePremiumWon) = policy.splitPayout(payout);
       borrowFromScr = _payFromPool(aux);
     } else {
       // Pay RM and Ensuro
-      _transferTo(policy.riskModule.wallet(), policy.premiumForRm + policy.rmScr());
+      _transferTo(policy.riskModule.wallet(), policy.premiumForRm);
       _transferTo(_config.treasury(), policy.premiumForEnsuro);
       purePremiumWon = policy.purePremium;
       // cover first _borrowedActivePP

--- a/contracts/TrustfulRiskModule.sol
+++ b/contracts/TrustfulRiskModule.sol
@@ -30,7 +30,6 @@ contract TrustfulRiskModule is RiskModule {
    * @param maxScrPerPolicy_ Max SCR to be allocated to this module (in wad)
    * @param scrLimit_ Max SCR to be allocated to this module (in wad)
    * @param wallet_ Address of the RiskModule provider
-   * @param sharedCoverageMinPercentage_ minimal % of SCR that must be covered by the RM
    */
   function initialize(
     string memory name_,
@@ -39,8 +38,7 @@ contract TrustfulRiskModule is RiskModule {
     uint256 scrInterestRate_,
     uint256 maxScrPerPolicy_,
     uint256 scrLimit_,
-    address wallet_,
-    uint256 sharedCoverageMinPercentage_
+    address wallet_
   ) public initializer {
     __RiskModule_init(
       name_,
@@ -49,8 +47,7 @@ contract TrustfulRiskModule is RiskModule {
       scrInterestRate_,
       maxScrPerPolicy_,
       scrLimit_,
-      wallet_,
-      sharedCoverageMinPercentage_
+      wallet_
     );
   }
 

--- a/deploySmokeTest.sh
+++ b/deploySmokeTest.sh
@@ -5,6 +5,12 @@ die() {
     exit 1
 }
 
+dieOnError() {
+    if [ $? -ne 0 ]; then
+        die $1
+    fi
+}
+
 NETWORK=${NETWORK:-localhost}
 
 if [ $NETWORK == "localhost" ]; then

--- a/interfaces/IRiskModule.sol
+++ b/interfaces/IRiskModule.sol
@@ -23,11 +23,5 @@ interface IRiskModule {
 
   function totalScr() external view returns (uint256);
 
-  function sharedCoverageMinPercentage() external view returns (uint256);
-
-  function sharedCoveragePercentage() external view returns (uint256);
-
-  function sharedCoverageScr() external view returns (uint256);
-
   function wallet() external view returns (address);
 }

--- a/prototype/wrappers.py
+++ b/prototype/wrappers.py
@@ -182,7 +182,7 @@ class EToken(IERC20):
 
 class Policy:
 
-    def __init__(self, id, payout, premium, scr, rm_coverage, loss_prob,
+    def __init__(self, id, payout, premium, scr, loss_prob,
                  pure_premium, premium_for_ensuro, premium_for_rm, premium_for_lps,
                  risk_module, start, expiration, address_book):
         self.id = id
@@ -190,7 +190,6 @@ class Policy:
         self.payout = Wad(payout)
         self.premium = Wad(premium)
         self.scr = Wad(scr)
-        self.rm_coverage = Wad(rm_coverage)
         self.loss_prob = Ray(loss_prob)
         self.start = start
         self.expiration = expiration
@@ -198,16 +197,6 @@ class Policy:
         self.premium_for_ensuro = Wad(premium_for_ensuro)
         self.premium_for_rm = Wad(premium_for_rm)
         self.premium_for_lps = Wad(premium_for_lps)
-
-    def _coverage_premium_split(self):
-        ens_premium = self.premium * (self.payout - self.rm_coverage) // self.payout
-        rm_premium = self.premium - ens_premium
-        return ens_premium, rm_premium
-
-    @property
-    def rm_scr(self):
-        ens_premium, rm_premium = self._coverage_premium_split()
-        return self.rm_coverage - rm_premium
 
     def premium_split(self):
         return self.pure_premium, self.premium_for_ensuro, self.premium_for_rm, self.premium_for_lps
@@ -234,21 +223,20 @@ class RiskModule(ETHWrapper):
     initialize_args = (
         ("name", "string"), ("scr_percentage", "ray"), ("ensuro_fee", "ray"),
         ("scr_interest_rate", "ray"), ("max_scr_per_policy", "amount"), ("scr_limit", "amount"),
-        ("wallet", "address"), ("shared_coverage_min_percentage", "ray")
+        ("wallet", "address")
     )
 
     def __init__(self, name, policy_pool, scr_percentage=_R(1), ensuro_fee=_R(0),
                  scr_interest_rate=_R(0), max_scr_per_policy=_W(1000000), scr_limit=_W(1000000),
-                 wallet="RM", shared_coverage_min_percentage=_R(0), owner="owner"):
+                 wallet="RM", owner="owner"):
         scr_percentage = _R(scr_percentage)
         ensuro_fee = _R(ensuro_fee)
         scr_interest_rate = _R(scr_interest_rate)
         max_scr_per_policy = _W(max_scr_per_policy)
         scr_limit = _W(scr_limit)
-        shared_coverage_min_percentage = _R(shared_coverage_min_percentage)
         super().__init__(owner, policy_pool.contract, name, scr_percentage, ensuro_fee,
                          scr_interest_rate,
-                         max_scr_per_policy, scr_limit, wallet, shared_coverage_min_percentage)
+                         max_scr_per_policy, scr_limit, wallet)
         self.policy_pool = policy_pool
         self._auto_from = self.owner
 
@@ -261,8 +249,6 @@ class RiskModule(ETHWrapper):
     scr_limit = MethodAdapter((), "amount", is_property=True)
     total_scr = MethodAdapter((), "amount", is_property=True)
     wallet = MethodAdapter((), "address", is_property=True)
-    shared_coverage_min_percentage = MethodAdapter((), "ray", is_property=True)
-    shared_coverage_percentage = MethodAdapter((), "ray", is_property=True)
 
     def new_policy(self, *args, **kwargs):
         receipt = self.new_policy_(*args, **kwargs)
@@ -314,18 +300,17 @@ class FlightDelayRiskModule(RiskModule):
 
     def __init__(self, name, policy_pool, scr_percentage=_R(1), ensuro_fee=_R(0),
                  scr_interest_rate=_R(0), max_scr_per_policy=_W(1000000), scr_limit=_W(1000000),
-                 wallet="RM", shared_coverage_min_percentage=_R(0), owner="owner",
+                 wallet="RM", owner="owner",
                  link_token=None, oracle_params=None):
         scr_percentage = _R(scr_percentage)
         ensuro_fee = _R(ensuro_fee)
         scr_interest_rate = _R(scr_interest_rate)
         max_scr_per_policy = _W(max_scr_per_policy)
         scr_limit = _W(scr_limit)
-        shared_coverage_min_percentage = _R(shared_coverage_min_percentage)
         super(RiskModule, self).__init__(
             owner, policy_pool.contract, name, scr_percentage, ensuro_fee,
             scr_interest_rate,
-            max_scr_per_policy, scr_limit, wallet, shared_coverage_min_percentage,
+            max_scr_per_policy, scr_limit, wallet,
             link_token, oracle_params
         )
         self.policy_pool = policy_pool

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -170,7 +170,7 @@ async function deployEToken({
 
 async function deployRiskModule({
       verify, rmClass, rmName, poolAddress, scrPercentage, scrInterestRate, ensuroFee, maxScrPerPolicy,
-      scrLimit, moc, wallet, sharedCoverageMinPercentage, extraArgs
+      scrLimit, moc, wallet, extraArgs
   }, hre) {
   extraArgs = extraArgs || [];
   const RiskModule = await hre.ethers.getContractFactory(rmClass);
@@ -182,7 +182,6 @@ async function deployRiskModule({
     _W(maxScrPerPolicy),
     _W(scrLimit),
     wallet,
-    _R(sharedCoverageMinPercentage),
     ...extraArgs
   ], {
     kind: 'uups',
@@ -439,7 +438,6 @@ function add_task() {
     .addOptionalParam("scrLimit", "Total SCR for the RM", 1e6, types.float)
     .addOptionalParam("moc", "Margin of Conservativism", 1.0, types.float)
     .addParam("wallet", "RM address", types.address)
-    .addOptionalParam("sharedCoverageMinPercentage", "Shared coverage minimum percentage", 0.0, types.float)
     .setAction(deployRiskModule);
 
   task("deploy:fdRiskModule", "Deploys and injects a Flight Delay RiskModule")
@@ -454,7 +452,6 @@ function add_task() {
     .addOptionalParam("scrLimit", "Total SCR for the RM", 1e6, types.float)
     .addOptionalParam("moc", "Margin of Conservativism", 1.0, types.float)
     .addParam("wallet", "RM address", types.address)
-    .addOptionalParam("sharedCoverageMinPercentage", "Shared coverage minimum percentage", 0.0, types.float)
     .addParam("linkToken", "LINK address", types.address)
     .addParam("oracle", "Oracle address", types.address)
     .addOptionalParam("oracleFee", "Oracle Fee", 0.1, types.float)

--- a/tests/test_policypool.py
+++ b/tests/test_policypool.py
@@ -773,8 +773,12 @@ def test_partial_payout(tenv):
 
 # TODO: more test cases of partial payout
 # - when payout < premium and payout > (premium - policy.premium_for_lps)
+#     - should take as pool loan (if the only policy) payout - (premium - premium_for_lps)
 # - when payout < premium and payout > (policy.pure_premium)
+#     - should increase won_pure_premiums with payout - (premium - premium_for_lps)
 # - when payout < premium and payout <= (policy.pure_premium)
+#     - should increase won_pure_premiums with payout - (premium - premium_for_lps)
+# TODO: define later if partial payouts pay to ensuro_fee and premium_for_rm if possible
 
 
 @set_precision(Wad, 3)
@@ -1287,8 +1291,8 @@ def test_expire_policy_payout(tenv):
 
     pool = load_config(StringIO(YAML_SETUP), tenv.module)
     timecontrol = tenv.time_control
-    etk = pool.etokens["eUSD1YEAR"]
-    USD = pool.currency
+    etk = pool.etokens["eUSD1YEAR"]  # noqa
+    USD = pool.currency  # noqa
     rm = pool.config.risk_modules["Flight Insurance"]
     rm.grant_role("PRICER_ROLE", rm.owner)
     rm.grant_role("RESOLVER_ROLE", rm.owner)

--- a/tests/test_riskmodule.py
+++ b/tests/test_riskmodule.py
@@ -61,7 +61,7 @@ def test_getset_rm_parameters(tenv):
         name="Roulette", scr_percentage=_R(1), ensuro_fee=_R("0.03"),
         scr_interest_rate=_R("0.02"),
         max_scr_per_policy=_W(1000), scr_limit=_W(1000000),
-        wallet="CASINO", shared_coverage_min_percentage=_R("0.5")
+        wallet="CASINO"
     )
     assert rm.name == "Roulette"
     assert rm.scr_percentage == _R(1)
@@ -70,8 +70,6 @@ def test_getset_rm_parameters(tenv):
     assert rm.max_scr_per_policy == _W(1000)
     assert rm.scr_limit == _W(1000000)
     assert rm.wallet == "CASINO"
-    rm.shared_coverage_min_percentage.assert_equal(_R(1/2))
-    rm.shared_coverage_percentage.assert_equal(_R(1/2))
 
     rm.grant_role("RM_PROVIDER_ROLE", "CASINO")  # Grant the role to the casino owner
     tenv.pool_config.grant_role("LEVEL2_ROLE", "L2_USER")  # Grant the role to the casino owner
@@ -85,8 +83,6 @@ def test_getset_rm_parameters(tenv):
         ("max_scr_per_policy", "L2_USER", _W(2000)),
         ("scr_limit", "L2_USER", _W(10000000)),
         ("wallet", "CASINO", "CASINO_POCKET"),
-        ("shared_coverage_min_percentage", "L2_USER", _R("0.3")),
-        ("shared_coverage_percentage", "CASINO", _R("0.35")),
     ]
 
     for attr_name, authorized_user, new_value in test_attributes:
@@ -102,18 +98,9 @@ def test_getset_rm_parameters(tenv):
 
         assert getattr(rm, attr_name) == new_value
 
-    with rm.as_("CASINO"), pytest.raises(RevertError, match="less than minimum"):
-        rm.shared_coverage_percentage = _R("0.25")  # Should be reverted because < 0.3 min_percentage
-
     if tenv.kind == "ethereum":
         with rm.as_("CASINO"), pytest.raises(RevertError):
             rm.wallet = None
-
-    with rm.as_("CASINO"):
-        rm.shared_coverage_percentage = _R("0.45")
-
-    rm.shared_coverage_percentage == _R("0.45")
-    rm.shared_coverage_min_percentage == _R("0.3")
 
 
 def test_getset_rm_parameters_tweaks(tenv):
@@ -123,7 +110,7 @@ def test_getset_rm_parameters_tweaks(tenv):
         name="Roulette", scr_percentage=_R(1), ensuro_fee=_R("0.03"),
         scr_interest_rate=_R("0.02"),
         max_scr_per_policy=_W(1000), scr_limit=_W(1e6),  # 1m
-        wallet="CASINO", shared_coverage_min_percentage=_R("0.5")
+        wallet="CASINO"
     )
     tenv.pool_config.grant_role("LEVEL1_ROLE", "L1_USER")
     tenv.pool_config.grant_role("LEVEL2_ROLE", "L2_USER")
@@ -144,7 +131,6 @@ def test_getset_rm_parameters_tweaks(tenv):
         ("moc", _R("2.1")),  # [0.5, 2]
         ("ensuro_fee", _R("1.01")),  # <= 1
         ("scr_interest_rate", _R("1.01")),  # <= 1
-        ("shared_coverage_min_percentage", _R("1.01")),  # <= 1
     ]
 
     for attr_name, attr_value in test_validations:
@@ -159,7 +145,6 @@ def test_getset_rm_parameters_tweaks(tenv):
         ("ensuro_fee", _R("0.05")),  # 30% allowed
         ("scr_limit", _W(2e6)),  # 10% allowed - previous 1e6
         ("max_scr_per_policy", _W(1400)),  # 30% allowed
-        ("shared_coverage_min_percentage", _R("0.25")),  # 30% allowed
     ]
 
     for attr_name, attr_value in test_exceeded_tweaks:
@@ -167,8 +152,6 @@ def test_getset_rm_parameters_tweaks(tenv):
             setattr(rm, attr_name, attr_value)
 
     rm.grant_role("RM_PROVIDER_ROLE", "CASINO")  # Grant the role to the casino owner
-    with rm.as_("CASINO"):
-        rm.shared_coverage_percentage = _R("0.8")  # To avoid min_percentage validation error
 
     assert rm.moc == _R("1")
 
@@ -180,7 +163,6 @@ def test_getset_rm_parameters_tweaks(tenv):
         ("ensuro_fee", _R("0.025")),  # 30% allowed - previous 3%
         ("scr_limit", _W(1.05e6)),  # 10% allowed - previous 1.05e6
         ("max_scr_per_policy", _W(1299)),  # 30% allowed - previous 1000
-        ("shared_coverage_min_percentage", _R("0.6")),  # 30% allowed - previous 50%
     ]
 
     for attr_name, attr_value in test_ok_tweaks:
@@ -196,8 +178,6 @@ def test_getset_rm_parameters_tweaks(tenv):
         ("ensuro_fee", _R("0.01")),
         ("scr_limit", _W(3e6)),
         ("max_scr_per_policy", _W(500)),
-        ("shared_coverage_min_percentage", _R(0)),
-        ("shared_coverage_min_percentage", _R("0.1")),
     ]
 
     for attr_name, attr_value in test_ok_l2_changes:
@@ -238,7 +218,7 @@ def test_avoid_repeated_tweaks(tenv):
         name="Roulette", scr_percentage=_R(1), ensuro_fee=_R("0.03"),
         scr_interest_rate=_R("0.02"),
         max_scr_per_policy=_W(1000), scr_limit=_W(1e6),  # 1m
-        wallet="CASINO", shared_coverage_min_percentage=_R("0.5")
+        wallet="CASINO"
     )
     tenv.pool_config.grant_role("LEVEL3_ROLE", "L3_USER")
 
@@ -268,7 +248,7 @@ def test_new_policy(tenv):
         name="Roulette", scr_percentage=_R(1), ensuro_fee=_R("0.02"),
         scr_interest_rate=_R("0.01"),
         max_scr_per_policy=_W(1000), scr_limit=_W(1000000),
-        wallet="CASINO", shared_coverage_min_percentage=_R("0.6")
+        wallet="CASINO"
     )
     assert rm.name == "Roulette"
     tenv.currency.transfer(tenv.currency.owner, "CUST1", _W(1))
@@ -286,11 +266,10 @@ def test_new_policy(tenv):
     policy.premium.assert_equal(_W(1))
     policy.payout.assert_equal(_W(36))
     policy.loss_prob.assert_equal(_R(1/37))
-    policy.rm_coverage.assert_equal(_W(36 * .6))
-    policy.scr.assert_equal(_W(35 * .4))
+    policy.scr.assert_equal(_W(35))
     assert policy.expiration == expiration
     assert (tenv.time_control.now - policy.start) < 60  # Must be now, giving 60 seconds tolerance
-    policy.pure_premium.assert_equal(_W(36 * .4 * 1/37))
+    policy.pure_premium.assert_equal(_W(36 * 1/37))
     policy.premium_for_ensuro.assert_equal(policy.pure_premium * _W("0.02"))
     policy.premium_for_lps.assert_equal(policy.scr * _W("0.01") * _W(7/365))
     policy.premium_for_rm.assert_equal(
@@ -312,7 +291,7 @@ def test_moc(tenv):
         name="Roulette", scr_percentage=_R(1), ensuro_fee=_R("0.01"),
         scr_interest_rate=_R(0),
         max_scr_per_policy=_W(1000), scr_limit=_W(1000000),
-        wallet="CASINO", shared_coverage_min_percentage=_R("0.6")
+        wallet="CASINO"
     )
     tenv.currency.transfer(tenv.currency.owner, "CUST1", _W(1))
     tenv.currency.approve("CUST1", rm.policy_pool, _W(1))
@@ -324,8 +303,8 @@ def test_moc(tenv):
 
     policy.premium.assert_equal(_W(1))
     policy.loss_prob.assert_equal(_R(1/37))
-    policy.pure_premium.assert_equal(_W(36 * .4 * 1/37))
-    policy.premium_for_ensuro.assert_equal(_W(36 * .4 * 1/37 * 0.01))
+    policy.pure_premium.assert_equal(_W(36 * 1/37))
+    policy.premium_for_ensuro.assert_equal(_W(36 * 1/37 * 0.01))
 
     with pytest.raises(RevertError, match="missing role"):
         rm.moc = _R("1.01")
@@ -341,7 +320,7 @@ def test_moc(tenv):
 
     policy2.premium.assert_equal(_W(1))
     policy2.loss_prob.assert_equal(_R(1/37))
-    policy2.pure_premium.assert_equal(_W(36 * .4 * 1/37) * _W("1.01"))
-    policy2.premium_for_ensuro.assert_equal(_W(36 * .4 * 1/37 * 0.01) * _W("1.01"))
+    policy2.pure_premium.assert_equal(_W(36 * 1/37) * _W("1.01"))
+    policy2.premium_for_ensuro.assert_equal(_W(36 * 1/37 * 0.01) * _W("1.01"))
 
 # TODO: further tests on _newPolicy validations


### PR DESCRIPTION
We were supporting an option of "shared coverage", where the risk module
covers a given percentage of the payout and takes the same percentage of
the premium. That payout was taken upfront from the risk partner,
requiring full collateralization on their side.

We are not sure this will be used in practice, so I removed it to
simplify the code and reduce gas cost.