### PR TITLE
Refactoring to save gas - Don't store policies

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,5 +17,5 @@ jobs:
       - run: npx hardhat size-contracts
       - run: npm run solhint
       - run: SKIP_PROXY=1 brownie test -v --gas
-      - run: brownie test -v
+      - run: brownie test -v --gas
       - run: ./deploySmokeTest.sh

--- a/contracts/FlightDelayRiskModule.sol
+++ b/contracts/FlightDelayRiskModule.sol
@@ -192,6 +192,6 @@ contract FlightDelayRiskModule is RiskModule, ChainlinkClientUpgradeable {
     bool customerWon = (actualArrivalDate <= 0 || // cancelled
       uint256(actualArrivalDate) > uint256(policy.expectedArrival + policy.tolerance)); // arrived after tolerance
 
-    _policyPool.resolvePolicyFullPayout(policyId, customerWon);
+    _resolvePolicyFullPayout(policyId, customerWon);
   }
 }

--- a/contracts/Policy.sol
+++ b/contracts/Policy.sol
@@ -76,9 +76,9 @@ library Policy {
     return policy;
   }
 
-  function splitPayout(PolicyData storage policy, uint256 payout)
+  function splitPayout(PolicyData memory policy, uint256 payout)
     internal
-    view
+    pure
     returns (uint256 toBePaidWithPool, uint256 premiumsWon)
   {
     uint256 nonCapitalPremiums = policy.premium - policy.premiumForLps;
@@ -90,7 +90,7 @@ library Policy {
     }
   }
 
-  function interestRate(PolicyData storage policy) internal view returns (uint256) {
+  function interestRate(PolicyData memory policy) internal pure returns (uint256) {
     return
       policy
         .premiumForLps
@@ -99,7 +99,7 @@ library Policy {
         .wadToRay();
   }
 
-  function accruedInterest(PolicyData storage policy) internal view returns (uint256) {
+  function accruedInterest(PolicyData memory policy) internal view returns (uint256) {
     uint256 secs = block.timestamp - policy.start;
     return
       policy
@@ -108,5 +108,9 @@ library Policy {
         .rayMul(secs * interestRate(policy))
         .rayDiv(SECONDS_IN_YEAR_RAY)
         .rayToWad();
+  }
+
+  function hash(PolicyData memory policy) internal pure returns (bytes32) {
+    return keccak256(abi.encode(policy));
   }
 }

--- a/contracts/PolicyNFT.sol
+++ b/contracts/PolicyNFT.sol
@@ -97,4 +97,8 @@ contract PolicyNFT is UUPSUpgradeable, ERC721Upgradeable, PausableUpgradeable, I
   ) internal override whenNotPaused {
     super._beforeTokenTransfer(from, to, tokenId);
   }
+
+  function nextId() external view returns (uint256) {
+    return _tokenIdCounter.current();
+  }
 }

--- a/contracts/PolicyPool.sol
+++ b/contracts/PolicyPool.sol
@@ -70,7 +70,6 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable {
   uint256 internal _borrowedActivePP; // amount borrowed from active pure premiums to pay defaulted policies
   uint256 internal _wonPurePremiums; // amount of pure premiums won from non-defaulted policies
 
-  // event NewPolicy(IRiskModule indexed riskModule, uint256 policyId);
   event NewPolicy(IRiskModule indexed riskModule, Policy.PolicyData policy);
   event PolicyRebalanced(IRiskModule indexed riskModule, uint256 indexed policyId);
   event PolicyResolved(IRiskModule indexed riskModule, uint256 indexed policyId, uint256 payout);
@@ -688,10 +687,6 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable {
       _payFromPool(amount); // return value should be 0 if not, losses are more than capital available
     }
   }
-
-  /*  function getPolicy(uint256 policyId) external view override returns (Policy.PolicyData memory) {
-    return _policies[policyId];
-  }*/
 
   function getPolicyFundCount(uint256 policyId) external view returns (uint256) {
     return _policiesFunds[policyId].length();

--- a/contracts/PolicyPool.sol
+++ b/contracts/PolicyPool.sol
@@ -61,7 +61,6 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable {
 
   DataTypes.ETokenStatusMap internal _eTokens;
 
-  // mapping(uint256 => Policy.PolicyData) internal _policies;
   mapping(uint256 => bytes32) internal _policies;
   mapping(uint256 => DataTypes.ETokenToWadMap) internal _policiesFunds;
 

--- a/contracts/PolicyPool.sol
+++ b/contracts/PolicyPool.sol
@@ -61,7 +61,8 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable {
 
   DataTypes.ETokenStatusMap internal _eTokens;
 
-  mapping(uint256 => Policy.PolicyData) internal _policies;
+  // mapping(uint256 => Policy.PolicyData) internal _policies;
+  mapping(uint256 => bytes32) internal _policies;
   mapping(uint256 => DataTypes.ETokenToWadMap) internal _policiesFunds;
 
   uint256 internal _activePremiums; // sum of premiums of active policies - In Wad
@@ -69,7 +70,8 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable {
   uint256 internal _borrowedActivePP; // amount borrowed from active pure premiums to pay defaulted policies
   uint256 internal _wonPurePremiums; // amount of pure premiums won from non-defaulted policies
 
-  event NewPolicy(IRiskModule indexed riskModule, uint256 policyId);
+  // event NewPolicy(IRiskModule indexed riskModule, uint256 policyId);
+  event NewPolicy(IRiskModule indexed riskModule, Policy.PolicyData policy);
   event PolicyRebalanced(IRiskModule indexed riskModule, uint256 indexed policyId);
   event PolicyResolved(IRiskModule indexed riskModule, uint256 indexed policyId, uint256 payout);
 
@@ -254,27 +256,27 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable {
     return withdrawed;
   }
 
-  function newPolicy(Policy.PolicyData memory policy_, address customer)
+  function newPolicy(Policy.PolicyData memory policy, address customer)
     external
     override
     whenNotPaused
     returns (uint256)
   {
-    IRiskModule rm = policy_.riskModule;
+    IRiskModule rm = policy.riskModule;
     require(address(rm) == msg.sender, "Only the RM can create new policies");
     _config.checkAcceptsNewPolicy(rm);
-    _currency.safeTransferFrom(customer, address(this), policy_.premium);
+    _currency.safeTransferFrom(customer, address(this), policy.premium);
     uint256 policyId = _policyNFT.safeMint(customer);
-    Policy.PolicyData storage policy = _policies[policyId] = policy_;
     policy.id = policyId;
+    _policies[policyId] = policy.hash();
     _activePurePremiums += policy.purePremium;
     _activePremiums += policy.premium;
     _lockScr(policy);
-    emit NewPolicy(rm, policy.id);
+    emit NewPolicy(rm, policy);
     return policy.id;
   }
 
-  function _lockScr(Policy.PolicyData storage policy) internal {
+  function _lockScr(Policy.PolicyData memory policy) internal {
     uint256 ocean = 0;
     DataTypes.ETokenToWadMap storage policyFunds = _policiesFunds[policy.id];
 
@@ -372,7 +374,7 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable {
   }
 
   function _processResolution(
-    Policy.PolicyData storage policy,
+    Policy.PolicyData memory policy,
     bool customerWon,
     uint256 payout
   ) internal returns (uint256, uint256) {
@@ -399,32 +401,37 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable {
     return (borrowFromScr, purePremiumWon);
   }
 
-  function expirePolicy(uint256 policyId) external whenNotPaused {
-    Policy.PolicyData storage policy = _policies[policyId];
-    require(policy.id == policyId && policyId != 0, "Policy not found");
+  function _validatePolicy(Policy.PolicyData memory policy) internal view {
+    require(policy.id != 0 && policy.hash() == _policies[policy.id], "Policy not found");
+  }
+
+  function expirePolicy(Policy.PolicyData calldata policy) external whenNotPaused {
     require(policy.expiration <= block.timestamp, "Policy not expired yet");
-    return _resolvePolicy(policyId, 0, true);
+    return _resolvePolicy(policy, 0, true);
   }
 
-  function resolvePolicy(uint256 policyId, uint256 payout) external override whenNotPaused {
-    return _resolvePolicy(policyId, payout, false);
-  }
-
-  function resolvePolicyFullPayout(uint256 policyId, bool customerWon)
+  function resolvePolicy(Policy.PolicyData calldata policy, uint256 payout)
     external
     override
     whenNotPaused
   {
-    return _resolvePolicy(policyId, customerWon ? _policies[policyId].payout : 0, false);
+    return _resolvePolicy(policy, payout, false);
+  }
+
+  function resolvePolicyFullPayout(Policy.PolicyData calldata policy, bool customerWon)
+    external
+    override
+    whenNotPaused
+  {
+    return _resolvePolicy(policy, customerWon ? policy.payout : 0, false);
   }
 
   function _resolvePolicy(
-    uint256 policyId,
+    Policy.PolicyData memory policy,
     uint256 payout,
     bool expired
   ) internal {
-    Policy.PolicyData storage policy = _policies[policyId];
-    require(policy.id == policyId && policyId != 0, "Policy not found");
+    _validatePolicy(policy);
     IRiskModule rm = policy.riskModule;
     require(expired || address(rm) == msg.sender, "Only the RM can resolve policies");
     require(payout == 0 || policy.expiration > block.timestamp, "Can't pay expired policy");
@@ -462,7 +469,7 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable {
     delete _policiesFunds[policy.id];
   }
 
-  function _interestAdjustment(Policy.PolicyData storage policy)
+  function _interestAdjustment(Policy.PolicyData memory policy)
     internal
     view
     returns (bool, uint256)
@@ -473,7 +480,7 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable {
     else return (false, aux - policy.premiumForLps);
   }
 
-  function _updatePolicyFundsCustWon(Policy.PolicyData storage policy, uint256 borrowFromScr)
+  function _updatePolicyFundsCustWon(Policy.PolicyData memory policy, uint256 borrowFromScr)
     internal
     returns (uint256)
   {
@@ -499,7 +506,7 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable {
   }
 
   // Almost duplicated code from _updatePolicyFundsCustWon but separated to avoid stack depth error
-  function _updatePolicyFundsCustLost(Policy.PolicyData storage policy, uint256 purePremiumWon)
+  function _updatePolicyFundsCustLost(Policy.PolicyData memory policy, uint256 purePremiumWon)
     internal
     returns (uint256)
   {
@@ -605,10 +612,13 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable {
     return amount;
   }
 
-  function rebalancePolicy(uint256 policyId) external onlyRole(REBALANCE_ROLE) whenNotPaused {
-    Policy.PolicyData storage policy = _policies[policyId];
-    require(policy.id == policyId && policyId != 0, "Policy not found");
-    DataTypes.ETokenToWadMap storage policyFunds = _policiesFunds[policyId];
+  function rebalancePolicy(Policy.PolicyData calldata policy)
+    external
+    onlyRole(REBALANCE_ROLE)
+    whenNotPaused
+  {
+    _validatePolicy(policy);
+    DataTypes.ETokenToWadMap storage policyFunds = _policiesFunds[policy.id];
     uint256 ocean = 0;
 
     // Iterates all the tokens
@@ -679,9 +689,9 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable {
     }
   }
 
-  function getPolicy(uint256 policyId) external view override returns (Policy.PolicyData memory) {
+  /*  function getPolicy(uint256 policyId) external view override returns (Policy.PolicyData memory) {
     return _policies[policyId];
-  }
+  }*/
 
   function getPolicyFundCount(uint256 policyId) external view returns (uint256) {
     return _policiesFunds[policyId].length();

--- a/contracts/RiskModule.sol
+++ b/contracts/RiskModule.sol
@@ -35,6 +35,8 @@ abstract contract RiskModule is IRiskModule, AccessControlUpgradeable, PolicyPoo
 
   address internal _wallet; // Address of the RiskModule provider
 
+  mapping(uint256 => Policy.PolicyData) private _policies;
+
   modifier validateParamsAfterChange() {
     _;
     _validateParameters();
@@ -292,6 +294,17 @@ abstract contract RiskModule is IRiskModule, AccessControlUpgradeable, PolicyPoo
     _totalScr += policy.scr;
     require(_totalScr <= _scrLimit, "RiskModule: SCR limit exceeded");
     uint256 policyId = _policyPool.newPolicy(policy, customer);
+    policy.id = policyId;
+    require(policy.id == policyId, "Error policy.id not set");
+    _policies[policyId] = policy;
     return policyId;
+  }
+
+  function _resolvePolicy(uint256 policyId, uint256 payout) internal {
+    _policyPool.resolvePolicy(_policies[policyId], payout);
+  }
+
+  function _resolvePolicyFullPayout(uint256 policyId, bool customerWon) internal {
+    _policyPool.resolvePolicyFullPayout(_policies[policyId], customerWon);
   }
 }

--- a/contracts/RiskModule.sol
+++ b/contracts/RiskModule.sol
@@ -35,8 +35,6 @@ abstract contract RiskModule is IRiskModule, AccessControlUpgradeable, PolicyPoo
 
   address internal _wallet; // Address of the RiskModule provider
 
-  mapping(uint256 => Policy.PolicyData) private _policies;
-
   modifier validateParamsAfterChange() {
     _;
     _validateParameters();
@@ -275,7 +273,7 @@ abstract contract RiskModule is IRiskModule, AccessControlUpgradeable, PolicyPoo
     uint256 lossProb,
     uint40 expiration,
     address customer
-  ) internal whenNotPaused returns (uint256) {
+  ) internal whenNotPaused returns (Policy.PolicyData memory) {
     require(premium < payout, "Premium must be less than payout");
     require(expiration > uint40(block.timestamp), "Expiration must be in the future");
     require(customer != address(0), "Customer can't be zero address");
@@ -295,16 +293,6 @@ abstract contract RiskModule is IRiskModule, AccessControlUpgradeable, PolicyPoo
     require(_totalScr <= _scrLimit, "RiskModule: SCR limit exceeded");
     uint256 policyId = _policyPool.newPolicy(policy, customer);
     policy.id = policyId;
-    require(policy.id == policyId, "Error policy.id not set");
-    _policies[policyId] = policy;
-    return policyId;
-  }
-
-  function _resolvePolicy(uint256 policyId, uint256 payout) internal {
-    _policyPool.resolvePolicy(_policies[policyId], payout);
-  }
-
-  function _resolvePolicyFullPayout(uint256 policyId, bool customerWon) internal {
-    _policyPool.resolvePolicyFullPayout(_policies[policyId], customerWon);
+    return policy;
   }
 }

--- a/contracts/TrustfulRiskModule.sol
+++ b/contracts/TrustfulRiskModule.sol
@@ -66,7 +66,7 @@ contract TrustfulRiskModule is RiskModule {
     onlyRole(RESOLVER_ROLE)
     whenNotPaused
   {
-    return _policyPool.resolvePolicy(policyId, payout);
+    return _resolvePolicy(policyId, payout);
   }
 
   function resolvePolicyFullPayout(uint256 policyId, bool customerWon)
@@ -74,6 +74,6 @@ contract TrustfulRiskModule is RiskModule {
     onlyRole(RESOLVER_ROLE)
     whenNotPaused
   {
-    return _policyPool.resolvePolicyFullPayout(policyId, customerWon);
+    return _resolvePolicyFullPayout(policyId, customerWon);
   }
 }

--- a/contracts/TrustfulRiskModule.sol
+++ b/contracts/TrustfulRiskModule.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 import {IPolicyPool} from "../interfaces/IPolicyPool.sol";
 import {RiskModule} from "./RiskModule.sol";
+import {Policy} from "./Policy.sol";
 
 /**
  * @title Trustful Risk Module
@@ -58,22 +59,22 @@ contract TrustfulRiskModule is RiskModule {
     uint40 expiration,
     address customer
   ) external onlyRole(PRICER_ROLE) returns (uint256) {
-    return _newPolicy(payout, premium, lossProb, expiration, customer);
+    return _newPolicy(payout, premium, lossProb, expiration, customer).id;
   }
 
-  function resolvePolicy(uint256 policyId, uint256 payout)
+  function resolvePolicy(Policy.PolicyData calldata policy, uint256 payout)
     external
     onlyRole(RESOLVER_ROLE)
     whenNotPaused
   {
-    return _resolvePolicy(policyId, payout);
+    _policyPool.resolvePolicy(policy, payout);
   }
 
-  function resolvePolicyFullPayout(uint256 policyId, bool customerWon)
+  function resolvePolicyFullPayout(Policy.PolicyData calldata policy, bool customerWon)
     external
     onlyRole(RESOLVER_ROLE)
     whenNotPaused
   {
-    return _resolvePolicyFullPayout(policyId, customerWon);
+    _policyPool.resolvePolicyFullPayout(policy, customerWon);
   }
 }

--- a/contracts/mocks/PolicyPoolMock.sol
+++ b/contracts/mocks/PolicyPoolMock.sol
@@ -92,11 +92,6 @@ contract PolicyPoolMock is IPolicyPool {
     return policyCount;
   }
 
-  /*  function getPolicy(uint256 policyId) external view override returns (Policy.PolicyData memory) {
-    return policies[policyId];
-  }
-*/
-
   function _resolvePolicy(Policy.PolicyData memory policy, uint256 payout) internal {
     require(policy.id != 0, "Policy not found");
     require(policy.hash() == policyHashes[policy.id], "Hash doesn't match");

--- a/interfaces/IPolicyPool.sol
+++ b/interfaces/IPolicyPool.sol
@@ -18,13 +18,13 @@ interface IPolicyPool {
 
   function newPolicy(Policy.PolicyData memory policy, address customer) external returns (uint256);
 
-  function resolvePolicy(uint256 policyId, uint256 payout) external;
+  function resolvePolicy(Policy.PolicyData calldata policy, uint256 payout) external;
 
-  function resolvePolicyFullPayout(uint256 policyId, bool customerWon) external;
+  function resolvePolicyFullPayout(Policy.PolicyData calldata policy, bool customerWon) external;
 
   function receiveGrant(uint256 amount) external;
 
-  function getPolicy(uint256 policyId) external view returns (Policy.PolicyData memory);
+  // function getPolicy(uint256 policyId) external view returns (Policy.PolicyData memory);
 
   function getInvestable() external view returns (uint256);
 

--- a/interfaces/IPolicyPool.sol
+++ b/interfaces/IPolicyPool.sol
@@ -24,8 +24,6 @@ interface IPolicyPool {
 
   function receiveGrant(uint256 amount) external;
 
-  // function getPolicy(uint256 policyId) external view returns (Policy.PolicyData memory);
-
   function getInvestable() external view returns (uint256);
 
   function getETokenCount() external view returns (uint256);

--- a/prototype/wrappers.py
+++ b/prototype/wrappers.py
@@ -294,14 +294,16 @@ class TrustfulRiskModule(RiskModule):
         ("customer", "address")
     ), "receipt")
 
-    resolve_policy_full_payout = MethodAdapter((("policy_id", "int"), ("customer_won", "bool")))
-    resolve_policy_ = MethodAdapter((("policy_id", "int"), ("payout", "amount")))
+    resolve_policy_full_payout = MethodAdapter((("policy", "tuple"), ("customer_won", "bool")))
+    resolve_policy_ = MethodAdapter((("policy", "tuple"), ("payout", "amount")))
 
     def resolve_policy(self, policy_id, customer_won_or_amount):
+        global policy_db
+        policy = policy_db.get_policy(self.policy_pool.contract.address, policy_id)
         if customer_won_or_amount is True or customer_won_or_amount is False:
-            return self.resolve_policy_full_payout(policy_id,  customer_won_or_amount)
+            return self.resolve_policy_full_payout(policy.as_tuple(),  customer_won_or_amount)
         else:
-            return self.resolve_policy_(policy_id,  customer_won_or_amount)
+            return self.resolve_policy_(policy.as_tuple(), customer_won_or_amount)
 
 
 class FlightDelayRiskModule(RiskModule):

--- a/prototype/wrappers.py
+++ b/prototype/wrappers.py
@@ -77,7 +77,7 @@ class EToken(IERC20):
         pool_loan_interest_rate = _R(pool_loan_interest_rate)
         liquidity_requirement = _R(liquidity_requirement)
         max_utilization_rate = _R(max_utilization_rate)
-        
+
         super().__init__(
             owner, policy_pool,
             name, symbol, expiration_period, liquidity_requirement,
@@ -188,6 +188,7 @@ class Policy:
                  pure_premium, premium_for_ensuro, premium_for_rm, premium_for_lps,
                  risk_module, start, expiration, address_book):
         self.id = id
+        self._risk_module = risk_module
         self.risk_module = address_book.get_name(risk_module)
         self.payout = Wad(payout)
         self.premium = Wad(premium)
@@ -217,6 +218,27 @@ class Policy:
             self.scr.to_ray() * seconds * self.interest_rate //
             Ray.from_value(SECONDS_IN_YEAR)
         ).to_wad()
+
+    def as_tuple(self):
+        return (
+            self.id, self.payout, self.premium, self.scr, self.loss_prob,
+            self.pure_premium, self.premium_for_ensuro, self.premium_for_rm, self.premium_for_lps,
+            self._risk_module, self.start, self.expiration
+        )
+
+
+class PolicyDB:
+    def __init__(self):
+        self._policies = {}
+
+    def add_policy(self, pool_address, policy):
+        self._policies[(pool_address, policy.id)] = policy
+
+    def get_policy(self, pool_address, policy_id):
+        return self._policies[(pool_address, policy_id)]
+
+
+policy_db = PolicyDB()
 
 
 class RiskModule(ETHWrapper):
@@ -255,9 +277,10 @@ class RiskModule(ETHWrapper):
     def new_policy(self, *args, **kwargs):
         receipt = self.new_policy_(*args, **kwargs)
         if "NewPolicy" in receipt.events:
-            policy_id = receipt.events["NewPolicy"]["policyId"]
-            policy_data = self.policy_pool.contract.getPolicy(policy_id)
-            return Policy(*policy_data, address_book=self.provider.address_book)
+            policy_data = receipt.events["NewPolicy"]["policy"]
+            policy = Policy(*policy_data, address_book=self.provider.address_book)
+            policy_db.add_policy(self.policy_pool.contract.address, policy)
+            return policy
         else:
             return None
 
@@ -480,7 +503,27 @@ class PolicyPool(ETHWrapper):
 
     get_policy_fund_count = MethodAdapter((("policy_id", "int"), ), "int")
     get_policy_fund = MethodAdapter((("policy_id", "int"), ("etoken", "contract")), "amount")
-    rebalance_policy = MethodAdapter((("policy_id", "int"), ))
+    rebalance_policy_ = MethodAdapter((
+        ("policy_id", "int", ),
+        ("payout", "amount", ),
+        ("premium", "amount", ),
+        ("scr", "amount", ),
+        ("loss_prob", "ray", ),
+        ("purePremium", "amount", ),
+        ("premiumForEnsuro", "amount", ),
+        ("premiumForRm", "amount", ),
+        ("premiumForLps", "amount", ),
+        ("riskModule", "address", ),
+        ("start", "int", ),
+        ("expiration", "int", ),
+    ))
+    rebalance_policy_ = MethodAdapter((("policy", "tuple"), ))
+
+    def rebalance_policy(self, policy_id):
+        global policy_db
+        policy = policy_db.get_policy(self.contract.address, policy_id)
+        return self.rebalance_policy_(policy.as_tuple())
+
     get_investable = MethodAdapter((), "amount")
     receive_grant = MethodAdapter((("sender", "msg.sender"), ("amount", "amount")))
 
@@ -494,7 +537,12 @@ class PolicyPool(ETHWrapper):
         else:
             return Wad(0)
 
-    expire_policy = MethodAdapter((("policy_id", "int"), ))
+    expire_policy_ = MethodAdapter((("policy", "tuple"), ))
+
+    def expire_policy(self, policy_id):
+        global policy_db
+        policy = policy_db.get_policy(self.contract.address, policy_id)
+        return self.expire_policy_(policy.as_tuple())
 
 
 class BaseAssetManager(ETHWrapper):


### PR DESCRIPTION
Instead of storing the policies in the blockchain, I just store a hash.

For every operation that involves a Policy, the policy data needs to be
sent and is later validated comparing with the stored hash.

(partially implemented, still have to remove the Policy storage in
riskmodule contract)