### PR TITLE
Deterministic Policy Id

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ RUN echo 'alias hh="npx hardhat"' >> /root/.bashrc
 ENV M9G_VALIDATE_TYPES "Y"
 ENV M9G_SERIALIZE_THIN "Y"
 
-RUN pip install --upgrade eth-prototype[brownie]==0.5.2
+RUN pip install --upgrade eth-prototype[brownie]>=0.6.2
+RUN pip install --upgrade eth-brownie==1.17.2
 RUN pip install pytest-timeout
 
 ENV PYTEST_TIMEOUT "300"

--- a/contracts/FlightDelayRiskModule.sol
+++ b/contracts/FlightDelayRiskModule.sol
@@ -119,7 +119,8 @@ contract FlightDelayRiskModule is RiskModule, ChainlinkClientUpgradeable {
     uint256 payout,
     uint256 premium,
     uint256 lossProb,
-    address customer
+    address customer,
+    uint96 internalId
   ) external onlyRole(PRICER_ROLE) returns (uint256) {
     require(expectedArrival > block.timestamp, "expectedArrival can't be in the past");
     require(departure != 0 && expectedArrival > departure, "expectedArrival <= departure!");
@@ -132,7 +133,8 @@ contract FlightDelayRiskModule is RiskModule, ChainlinkClientUpgradeable {
       premium,
       lossProb,
       expiration,
-      customer
+      customer,
+      internalId
     );
     PolicyData storage policy = _policies[ensuroPolicy.id];
     policy.ensuroPolicy = ensuroPolicy;

--- a/contracts/PolicyNFT.sol
+++ b/contracts/PolicyNFT.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.2;
 
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {ERC721Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
-import {CountersUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol";
 import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 import {IPolicyPool} from "../interfaces/IPolicyPool.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
@@ -18,12 +17,9 @@ import {IPolicyNFT} from "../interfaces/IPolicyNFT.sol";
  * @author Ensuro
  */
 contract PolicyNFT is UUPSUpgradeable, ERC721Upgradeable, PausableUpgradeable, IPolicyNFT {
-  using CountersUpgradeable for CountersUpgradeable.Counter;
-
   bytes32 public constant GUARDIAN_ROLE = keccak256("GUARDIAN_ROLE");
   bytes32 public constant LEVEL1_ROLE = keccak256("LEVEL1_ROLE");
 
-  CountersUpgradeable.Counter private _tokenIdCounter;
   IPolicyPool internal _policyPool;
 
   modifier onlyPolicyPool() {
@@ -55,7 +51,6 @@ contract PolicyNFT is UUPSUpgradeable, ERC721Upgradeable, PausableUpgradeable, I
   // solhint-disable-next-line func-name-mixedcase
   function __PolicyNFT_init_unchained(IPolicyPool policyPool_) internal initializer {
     _policyPool = policyPool_;
-    _tokenIdCounter.increment(); // I don't want _tokenId==0
   }
 
   // solhint-disable-next-line no-empty-blocks
@@ -83,11 +78,8 @@ contract PolicyNFT is UUPSUpgradeable, ERC721Upgradeable, PausableUpgradeable, I
     // require(_policyPool.policyNFT() == address(this), "PolicyPool not connected to this config");
   }
 
-  function safeMint(address to) external override onlyPolicyPool whenNotPaused returns (uint256) {
-    uint256 tokenId = _tokenIdCounter.current();
-    _safeMint(to, tokenId);
-    _tokenIdCounter.increment();
-    return tokenId;
+  function safeMint(address to, uint256 policyId) external override onlyPolicyPool whenNotPaused {
+    _safeMint(to, policyId, "");
   }
 
   function _beforeTokenTransfer(
@@ -96,9 +88,5 @@ contract PolicyNFT is UUPSUpgradeable, ERC721Upgradeable, PausableUpgradeable, I
     uint256 tokenId
   ) internal override whenNotPaused {
     super._beforeTokenTransfer(from, to, tokenId);
-  }
-
-  function nextId() external view returns (uint256) {
-    return _tokenIdCounter.current();
   }
 }

--- a/contracts/RiskModule.sol
+++ b/contracts/RiskModule.sol
@@ -294,7 +294,8 @@ abstract contract RiskModule is IRiskModule, AccessControlUpgradeable, PolicyPoo
     uint256 premium,
     uint256 lossProb,
     uint40 expiration,
-    address customer
+    address customer,
+    uint96 internalId
   ) internal whenNotPaused returns (Policy.PolicyData memory) {
     require(premium < payout, "Premium must be less than payout");
     require(expiration > uint40(block.timestamp), "Expiration must be in the future");
@@ -313,7 +314,7 @@ abstract contract RiskModule is IRiskModule, AccessControlUpgradeable, PolicyPoo
     require(policy.scr <= _maxScrPerPolicy, "RiskModule: SCR is more than maximum per policy");
     _totalScr += policy.scr;
     require(_totalScr <= _scrLimit, "RiskModule: SCR limit exceeded");
-    uint256 policyId = _policyPool.newPolicy(policy, customer);
+    uint256 policyId = _policyPool.newPolicy(policy, customer, internalId);
     policy.id = policyId;
     return policy;
   }

--- a/contracts/TrustfulRiskModule.sol
+++ b/contracts/TrustfulRiskModule.sol
@@ -57,9 +57,10 @@ contract TrustfulRiskModule is RiskModule {
     uint256 premium,
     uint256 lossProb,
     uint40 expiration,
-    address customer
+    address customer,
+    uint96 internalId
   ) external onlyRole(PRICER_ROLE) returns (uint256) {
-    return _newPolicy(payout, premium, lossProb, expiration, customer).id;
+    return _newPolicy(payout, premium, lossProb, expiration, customer, internalId).id;
   }
 
   function resolvePolicy(Policy.PolicyData calldata policy, uint256 payout)

--- a/deploySmokeTest-fork.sh
+++ b/deploySmokeTest-fork.sh
@@ -11,7 +11,7 @@ dieOnError() {
     fi
 }
 
-export AMOUNT_DECIMALS=6
+export DEPLOY_AMOUNT_DECIMALS=6
 
 NETWORK=${NETWORK:-localhost}
 

--- a/deploySmokeTest.sh
+++ b/deploySmokeTest.sh
@@ -11,7 +11,7 @@ dieOnError() {
     fi
 }
 
-export AMOUNT_DECIMALS=6
+export DEPLOY_AMOUNT_DECIMALS=6
 
 NETWORK=${NETWORK:-localhost}
 

--- a/interfaces/IPolicyNFT.sol
+++ b/interfaces/IPolicyNFT.sol
@@ -9,7 +9,7 @@ import {IERC721Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC7
  * @author Ensuro
  */
 interface IPolicyNFT is IERC721Upgradeable {
-  function safeMint(address to) external returns (uint256);
+  function safeMint(address to, uint256 policyId) external;
 
   function connect() external;
 }

--- a/interfaces/IPolicyPool.sol
+++ b/interfaces/IPolicyPool.sol
@@ -16,7 +16,11 @@ interface IPolicyPool {
 
   function setAssetManager(IAssetManager newAssetManager) external;
 
-  function newPolicy(Policy.PolicyData memory policy, address customer) external returns (uint256);
+  function newPolicy(
+    Policy.PolicyData memory policy,
+    address customer,
+    uint96 internalId
+  ) external returns (uint256);
 
   function resolvePolicy(Policy.PolicyData calldata policy, uint256 payout) external;
 

--- a/prototype/wrappers.py
+++ b/prototype/wrappers.py
@@ -292,6 +292,10 @@ class RiskModule(ETHWrapper):
         else:
             return None
 
+    def make_policy_id(self, internal_id):
+        rm_addr = self.contract.address
+        return (int(rm_addr, 16) << 96) + internal_id
+
 
 class TrustfulRiskModule(RiskModule):
     eth_contract = "TrustfulRiskModule"
@@ -299,7 +303,7 @@ class TrustfulRiskModule(RiskModule):
 
     new_policy_ = MethodAdapter((
         ("payout", "amount"), ("premium", "amount"), ("loss_prob", "ray"), ("expiration", "int"),
-        ("customer", "address")
+        ("customer", "address"), ("internal_id", "int"),
     ), "receipt")
 
     resolve_policy_full_payout = MethodAdapter((("policy", Policy.FIELDS), ("customer_won", "bool")))
@@ -324,7 +328,8 @@ class FlightDelayRiskModule(RiskModule):
 
     new_policy_ = MethodAdapter((
         ("flight", "string"), ("departure", "int"), ("expectedArrival", "int"), ("tolerance", "int"),
-        ("payout", "amount"), ("premium", "amount"), ("loss_prob", "ray"), ("customer", "address")
+        ("payout", "amount"), ("premium", "amount"), ("loss_prob", "ray"), ("customer", "address"),
+        ("internal_id", "int"),
     ), "receipt")
 
     resolve_policy = MethodAdapter((("policy_id", "int"), ))

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -20,7 +20,7 @@ function _R(value) {
 }
 
 function amountDecimals() {
-  let decimals = Number.parseInt(process.env.AMOUNT_DECIMALS);
+  let decimals = Number.parseInt(process.env.DEPLOY_AMOUNT_DECIMALS);
   console.assert(decimals >= 6);
   return decimals;
 }

--- a/tests/test_flightdelayrm.py
+++ b/tests/test_flightdelayrm.py
@@ -118,6 +118,7 @@ def test_flightdelay_new_policy_resolved_payout0(tenv):
     new_policy_params = (
         "AR 1234", now + 3600, expected_arrival, 1800,  # flight, departure, expectedArrival, tolerance
         _W(1000), _W(100), _R("0.1"), "CUST1",  # payout, premium, loss_prob, cust
+        123
     )
 
     with pytest.raises(RevertError, match="AccessControl"):
@@ -129,7 +130,7 @@ def test_flightdelay_new_policy_resolved_payout0(tenv):
     assert tenv.link_token.last_transfer_to == mock_oracle.address
     assert tenv.link_token.last_transfer_value == _W("0.1")
     assert tenv.link_token.last_transfer_data
-    assert policy.id == 1
+    assert policy.id == rm.make_policy_id(123)
 
     assert "ChainlinkRequested" in rm.last_receipt.events
     query_id = rm.last_receipt.events["ChainlinkRequested"]["id"]
@@ -140,7 +141,7 @@ def test_flightdelay_new_policy_resolved_payout0(tenv):
     assert "ChainlinkFulfilled" in receipt.events and "PolicyResolved" in receipt.events
     assert receipt.events["ChainlinkFulfilled"]["id"] == query_id
     assert receipt.events["PolicyResolved"]["payout"] == 0
-    assert receipt.events["PolicyResolved"]["policyId"] == 1
+    assert receipt.events["PolicyResolved"]["policyId"] == rm.make_policy_id(123)
 
 
 def test_flightdelay_new_policy_resolved_payout_full(tenv):
@@ -154,6 +155,7 @@ def test_flightdelay_new_policy_resolved_payout_full(tenv):
     new_policy_params = (
         "AR 1234", now + 3600, expected_arrival, 1800,  # flight, departure, expectedArrival, tolerance
         _W(1000), _W(100), _R("0.1"), "CUST1",  # payout, premium, loss_prob, cust
+        111
     )
 
     with rm.as_("BACKEND"):
@@ -182,6 +184,7 @@ def test_flightdelay_new_policy_flight_cancelled(tenv):
     new_policy_params = (
         "AR 1234", now + 3600, expected_arrival, 1800,  # flight, departure, expectedArrival, tolerance
         _W(1000), _W(100), _R("0.1"), "CUST1",  # payout, premium, loss_prob, cust
+        1122
     )
 
     with rm.as_("BACKEND"):
@@ -210,6 +213,7 @@ def test_flightdelay_zero_arrival_date(tenv):
     new_policy_params = (
         "AR 1234", now + 3600, expected_arrival, 1800,  # flight, departure, expectedArrival, tolerance
         _W(1000), _W(100), _R("0.1"), "CUST1",  # payout, premium, loss_prob, cust
+        2323
     )
 
     with rm.as_("BACKEND"):
@@ -257,6 +261,7 @@ def test_flightdelay_resolve_manual_cancelled(tenv):
     new_policy_params = (
         "AR 1234", now + 3600, expected_arrival, 1800,  # flight, departure, expectedArrival, tolerance
         _W(1000), _W(100), _R("0.1"), "CUST1",  # payout, premium, loss_prob, cust
+        333
     )
 
     with rm.as_("BACKEND"):
@@ -293,6 +298,7 @@ def test_flightdelay_resolve_manual_on_time(tenv):
     new_policy_params = (
         "AR 1234", now + 3600, expected_arrival, 1800,  # flight, departure, expectedArrival, tolerance
         _W(1000), _W(100), _R("0.1"), "CUST1",  # payout, premium, loss_prob, cust
+        2121
     )
 
     with rm.as_("BACKEND"):


### PR DESCRIPTION
Before this change, the policyId number it's known only after the
newPolicy transaction is processed, because it was a counter in the
PolicyNFT contract.

This was a problem for partners integrating with us that need to avoid
duplicated policies and need to match their internal id with the
Ensuro's Policy Id.

With this change, the user needs to send a `internalId` parameter and
the resulting policyId is created merging this internalId with the Risk
Module address:

`policyId = uint256(riskModule.address) << 96 + internalId`

This way we can know in advance the policyId and at the same time we
avoid colission of the numbers between two different modules.