### PR TITLE
Removes horizonal SCR split

### DIFF
--- a/contracts/PolicyPool.sol
+++ b/contracts/PolicyPool.sol
@@ -424,12 +424,8 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable {
 
     if (borrowFromScr > 0) {
       borrowFromScr = borrowFromScr - etk.lendToPool(borrowFromScr, true);
-      if (borrowFromScr > NEGLIGIBLE_AMOUNT)
-        borrowFromScr = _takeLoanFromAnyEtk(borrowFromScr);
-      require(
-        borrowFromScr <= NEGLIGIBLE_AMOUNT,
-        "Don't know where to take the rest of the money"
-      );
+      if (borrowFromScr > NEGLIGIBLE_AMOUNT) borrowFromScr = _takeLoanFromAnyEtk(borrowFromScr);
+      require(borrowFromScr <= NEGLIGIBLE_AMOUNT, "Don't know where to take the rest of the money");
     } else if (purePremiumWon > 0 && etk.getPoolLoan() > 0) {
       uint256 aux = Math.min(purePremiumWon, etk.getPoolLoan());
       etk.repayPoolLoan(aux);


### PR DESCRIPTION
Until now, the SCR of a policy was split between several eTokens. This
was adding a lot of complexity that's not really needed, since most of
the time just one eToken accepts a policy.

Now, each policy has a single solvency eToken. We still keep the
expiration limit at the eToken level, but now it's not so relevant.

Work in progress, change done only in the Python code, missing the
Solidity Code.