### PR TITLE
Renamed poolLoan to internalLoan

### DIFF
--- a/contracts/RiskModule.sol
+++ b/contracts/RiskModule.sol
@@ -300,6 +300,16 @@ abstract contract RiskModule is IRiskModule, PolicyPoolComponent {
     return purePremium + ensuroCommission + (jrCoc + srCoc);
   }
 
+  /**
+   * @dev Called from child contracts to create policies (after they validated the pricing)
+   *
+   * @param payout The exposure (maximum payout) of the policy
+   * @param premium The premium that will be paid by the policyHolder
+   * @param lossProb The probability of having to pay the maximum payout (wad)
+   * @param expiration The expiration of the policy (timestamp)
+   * @param customer The policy holder
+   * @param internalId An id that's unique within this module and it will be used to identify the policy
+   */
   function _newPolicy(
     uint256 payout,
     uint256 premium,

--- a/contracts/interfaces/IEToken.sol
+++ b/contracts/interfaces/IEToken.sol
@@ -118,13 +118,13 @@ interface IEToken is IERC20 {
 
   /**
    * @dev Lends `amount` to the borrower (msg.sender), transferring the money to `receiver`. This reduces the
-   * `totalSupply()` of the eToken, and stores a debt that will be repaid (hopefully) with `repayPoolLoan`.
+   * `totalSupply()` of the eToken, and stores a debt that will be repaid (hopefully) with `repayLoan`.
    *
    * Requirements:
    * - Must be called by a _borrower_ previously added with `addBorrower`.
    *
    * Events:
-   * - Emits {PoolLoan}
+   * - Emits {InternalLoan}
    * - Emits {ERC20-Transfer} transferring `lent` to `receiver`
    *
    * @param amount The amount required
@@ -133,32 +133,32 @@ interface IEToken is IERC20 {
    * locked as `scr()`. If `false`, all the `totalSupply()` is available to be lent.
    * @return Returns the amount that wasn't able to fulfil. `amount - lent`
    */
-  function lendToPool(
+  function internalLoan(
     uint256 amount,
     address receiver,
     bool fromAvailable
   ) external returns (uint256);
 
   /**
-   * @dev Repays a loan taken with `lendToPool`.
+   * @dev Repays a loan taken with `internalLoan`.
    *
    * Requirements:
    * - `msg.sender` approved the spending of `currency()` for at least `amount`
 
    * Events:
-   * - Emits {PoolLoanRepaid}
+   * - Emits {InternalLoanRepaid}
    * - Emits {ERC20-Transfer} transferring `amount` from `msg.sender` to `this`
    *
    * @param amount The amount to repaid, that will be transferred from `msg.sender` balance.
    * @param onBehalfOf The address of the borrower that took the loan. Usually `onBehalfOf == msg.sender` but we keep it
    * open because in some cases with might need someone else pays the debt.
    */
-  function repayPoolLoan(uint256 amount, address onBehalfOf) external;
+  function repayLoan(uint256 amount, address onBehalfOf) external;
 
   /**
    * @dev Returns the updated debt (principal + interest) of the `borrower`.
    */
-  function getPoolLoan(address borrower) external view returns (uint256);
+  function getLoan(address borrower) external view returns (uint256);
 
   /**
    * @dev The annualized interest rate at which the `totalSupply()` grows

--- a/contracts/interfaces/IPolicyPoolConfig.sol
+++ b/contracts/interfaces/IPolicyPoolConfig.sol
@@ -44,7 +44,7 @@ interface IPolicyPoolConfig is IAccessControlUpgradeable {
     setLiquidityRequirement,
     setMinUtilizationRate,
     setMaxUtilizationRate,
-    setPoolLoanInterestRate,
+    setInternalLoanInterestRate,
     etkFiller1, // Reserve space for future EToken actions
     etkFiller2, // Reserve space for future EToken actions
     etkFiller3, // Reserve space for future EToken actions

--- a/contracts/interfaces/IPremiumsAccount.sol
+++ b/contracts/interfaces/IPremiumsAccount.sol
@@ -10,17 +10,62 @@ import {Policy} from "../Policy.sol";
  * @author Ensuro
  */
 interface IPremiumsAccount {
+  /**
+   * @dev Adds a policy to the PremiumsAccount. Stores the pure premiums and locks the aditional funds from junior and
+   * senior eTokens.
+   *
+   * Requirements:
+   * - Must be called by `policyPool()`
+   *
+   * Events:
+   * - {EToken-SCRLocked}
+   *
+   * @param policy The policy to add (created in this transaction)
+   */
   function policyCreated(Policy.PolicyData memory policy) external;
 
+  /**
+   * @dev The PremiumsAccount is notified that the policy was resolved and issues the payout to the policyHolder.
+   *
+   * Requirements:
+   * - Must be called by `policyPool()`
+   *
+   * Events:
+   * - {ERC20-Transfer}: `to == policyHolder`, `amount == payout`
+   * - {EToken-InternalLoan}: optional, if a loan needs to be taken
+   * - {EToken-SCRUnlocked}
+   *
+   * @param policyHolder The one that will receive the payout
+   * @param policy The policy that was resolved
+   * @param payout The amount that has to be transferred to `policyHolder`
+   */
   function policyResolvedWithPayout(
-    address policyOwner,
+    address policyHolder,
     Policy.PolicyData memory policy,
     uint256 payout
   ) external;
 
+  /**
+   * @dev The PremiumsAccount is notified that the policy has expired, unlocks the SCR and earns the pure premium.
+   *
+   * Requirements:
+   * - Must be called by `policyPool()`
+   *
+   * Events:
+   * - {ERC20-Transfer}: `to == policyHolder`, `amount == payout`
+   * - {EToken-InternalLoanRepaid}: optional, if a loan was taken before
+   *
+   * @param policy The policy that has expired
+   */
   function policyExpired(Policy.PolicyData memory policy) external;
 
+  /**
+   * @dev The senior eToken, the secondary source of solvency, used if the premiums account is exhausted and junior too
+   */
   function seniorEtk() external view returns (IEToken);
 
+  /**
+   * @dev The junior eToken, the primary source of solvency, used if the premiums account is exhausted.
+   */
   function juniorEtk() external view returns (IEToken);
 }

--- a/contracts/interfaces/IRiskModule.sol
+++ b/contracts/interfaces/IRiskModule.sol
@@ -46,6 +46,14 @@ interface IRiskModule {
 
   function wallet() external view returns (address);
 
+  /**
+   * @dev Called when a policy expires or is resolved to update the exposure.
+   *
+   * Requirements:
+   * - Must be called by `policyPool()`
+   *
+   * @param payout The exposure (maximum payout) of the policy
+   */
   function releaseExposure(uint256 payout) external;
 
   function premiumsAccount() external view returns (IPremiumsAccount);

--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
 
+source `dirname $0`/utils.sh
+
 if [ "xx$1" == "xxclean" ]; then
     rm -fR docs
     shift
 fi
 
 npx hardhat docgen
+dieOnError "Error generating docs with solidity-docgen"
+
 npx prettier --write docs
+dieOnError "Error running prettier"
 
 cp README.md docs/index.md
 cp -r CONTRIBUTING.md CODE_OF_CONDUCT.md audits docs/


### PR DESCRIPTION
Pool is an ambigous name and we were using this because previously the
loads where given to the PolicyPool. Now are given to the premiums
accounts.

Also added some docs.