### PR TITLE
Upload coverage badge only on merge to master

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,6 +30,7 @@ jobs:
           ALCHEMY_URL: ${{ secrets.ALCHEMY_URL }}
       - run: node instrumented/coverage.js
       - name: Create coverage badge
+        if: github.ref == 'refs/heads/main'
         run: |
           set -x
           COVERAGE_BADGE=badges/coverage.svg

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Tests](https://github.com/ensuro/ensuro/actions/workflows/tests.yaml/badge.svg)](https://github.com/ensuro/ensuro/actions/workflows/tests.yaml)
-[![cov](badges/coverage.svg)](https://github.com/ensuro/ensuro/actions/workflows/tests.yaml)
+[![cov](https://github.com/ensuro/ensuro/raw/main/badges/coverage.svg)](https://github.com/ensuro/ensuro/actions/workflows/tests.yaml)
 [![Build and Push Docker Image to Google Artifact Registry](https://github.com/ensuro/ensuro/actions/workflows/build-base-image.yaml/badge.svg)](https://github.com/ensuro/ensuro/actions/workflows/build-base-image.yaml)
 [![release](https://badgen.net/github/release/ensuro/ensuro)](https://github.com/ensuro/ensuro/releases)
 


### PR DESCRIPTION
This reduces commit noise and makes the reference to the image absolute so it works across al sites where we publish the readme.