### PR TITLE
Npm upload

### DIFF
--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -16,7 +16,6 @@ jobs:
     name: NPM Package Build and Upload
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: semver
 
     steps:
       - name: Checkout

--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -12,16 +12,31 @@ jobs:
     name: NPM Package Build and Upload
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs: semver
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
       - uses: actions/setup-node@v3
         with:
           node-version: "16"
           cache: "npm"
+
       - run: npm ci
-      - run: scripts/make-npm-package.sh ./build/npm-package
+
+      - id: semver
+        run: |
+          SEMVER="${{ github.event.inputs.version }}"
+          if [ -z "$SEMVER" ]; then
+            # No manual input, we must be running on a tag
+            SEMVER="${GITHUB_REF/refs\/tags\/v/}"
+          fi
+          echo "::set-output name=semver::${SEMVER}"
+
+      - run: scripts/make-npm-package.sh "${{ steps.semver.outputs.semver }}" ./build/npm-package
+
       - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTOMATION_TOKEN }}" > ./build/npm-package/.npmrc
+
       - run: npm publish
         working-directory: ./build/npm-package

--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -22,7 +22,6 @@ jobs:
           cache: "npm"
       - run: npm ci
       - run: scripts/make-npm-package.sh ./build/npm-package
+      - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTOMATION_TOKEN }}" > ./build/npm-package/.npmrc
       - run: npm publish
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}
         working-directory: ./build/npm-package

--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -6,6 +6,10 @@ on:
     tags:
       - v*
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Package version"
+        required: true
 
 jobs:
   npm-upload:

--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -24,5 +24,5 @@ jobs:
       - run: scripts/make-npm-package.sh ./build/npm-package
       - run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}
         working-directory: ./build/npm-package

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![cov](badges/coverage.svg)](https://github.com/ensuro/ensuro/actions/workflows/tests.yaml)
 [![Build and Push Docker Image to Google Artifact Registry](https://github.com/ensuro/ensuro/actions/workflows/build-base-image.yaml/badge.svg)](https://github.com/ensuro/ensuro/actions/workflows/build-base-image.yaml)
 [![release](https://badgen.net/github/release/ensuro/ensuro)](https://github.com/ensuro/ensuro/releases)
+[![NPM Package](https://github.com/ensuro/ensuro/actions/workflows/npm.yaml/badge.svg)](https://www.npmjs.com/package/@ensuro/core)
 
 # Ensuro - Decentralized capital for insurance
 

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ensuro/core",
   "description": "Ensuro - Decentralized insurance protocol",
-  "version": "2.0.0-beta1",
+  "version": "2.0.0-beta2",
   "files": [
     "**/*.sol",
     "/build/contracts/*.json",

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ensuro/core",
   "description": "Ensuro - Decentralized insurance protocol",
-  "version": "2.0.0-beta2",
+  "version": "%%VERSION%%",
   "files": [
     "**/*.sol",
     "/build/contracts/*.json",

--- a/scripts/make-npm-package.sh
+++ b/scripts/make-npm-package.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
 
-TARGET_DIR=$1
+set -e
 
+VERSION=$1
+shift
+
+if [ -z $VERSION ]; then
+    echo "Usage: $0 <version> [<target dir>]" >&2
+    exit 13
+fi
+
+TARGET_DIR=$1
 if [ -z $TARGET_DIR ]; then
     TARGET_DIR=./build/npm-package/
 fi
@@ -23,7 +32,7 @@ mkdir $TARGET_DIR/js
 cp test/test-utils.js $TARGET_DIR/js/
 
 find $TARGET_DIR -name "*.dbg.json" -delete
-cp npm-package/package.json $TARGET_DIR
+sed "s/%%VERSION%%/$VERSION/" npm-package/package.json > "$TARGET_DIR/package.json"
 
 echo "
 


### PR DESCRIPTION
We may omit the management of the version number and handle it directly on the package.json, but it seemed to be simple enough and is one less thing to worry about when releasing.