### PR TITLE
Fix QSP-1 Uninitialized Implementation Contracts

### DIFF
--- a/contracts/AccessManager.sol
+++ b/contracts/AccessManager.sol
@@ -24,6 +24,11 @@ contract AccessManager is Initializable, AccessControlUpgradeable, UUPSUpgradeab
     _;
   }
 
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+
   function initialize() public initializer {
     __AccessControl_init();
     __UUPSUpgradeable_init();

--- a/contracts/AccessManager.sol
+++ b/contracts/AccessManager.sol
@@ -31,7 +31,7 @@ contract AccessManager is Initializable, AccessControlUpgradeable, UUPSUpgradeab
   }
 
   // solhint-disable-next-line func-name-mixedcase
-  function __AccessManager_init_unchained() internal initializer {
+  function __AccessManager_init_unchained() internal onlyInitializing {
     _setupRole(DEFAULT_ADMIN_ROLE, _msgSender());
   }
 

--- a/contracts/EToken.sol
+++ b/contracts/EToken.sol
@@ -100,7 +100,7 @@ contract EToken is Reserve, IERC20Metadata, IEToken {
     string memory symbol_,
     uint256 maxUtilizationRate_,
     uint256 internalLoanInterestRate_
-  ) internal initializer {
+  ) internal onlyInitializing {
     _name = name_;
     _symbol = symbol_;
     _tsScaled.init();

--- a/contracts/PolicyPool.sol
+++ b/contracts/PolicyPool.sol
@@ -205,7 +205,7 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
   }
 
   // solhint-disable-next-line func-name-mixedcase
-  function __PolicyPool_init_unchained(address treasury_) internal initializer {
+  function __PolicyPool_init_unchained(address treasury_) internal onlyInitializing {
     _treasury = treasury_;
   }
 

--- a/contracts/PolicyPool.sol
+++ b/contracts/PolicyPool.sol
@@ -182,6 +182,7 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
    */
   /// @custom:oz-upgrades-unsafe-allow constructor
   constructor(IAccessManager access_, IERC20Metadata currency_) {
+    _disableInitializers();
     _access = access_;
     _currency = currency_;
   }

--- a/contracts/PolicyPoolComponent.sol
+++ b/contracts/PolicyPoolComponent.sol
@@ -79,6 +79,7 @@ abstract contract PolicyPoolComponent is
 
   /// @custom:oz-upgrades-unsafe-allow constructor
   constructor(IPolicyPool policyPool_) {
+    _disableInitializers();
     _policyPool = policyPool_;
   }
 

--- a/contracts/PolicyPoolComponent.sol
+++ b/contracts/PolicyPoolComponent.sol
@@ -83,7 +83,7 @@ abstract contract PolicyPoolComponent is
   }
 
   // solhint-disable-next-line func-name-mixedcase
-  function __PolicyPoolComponent_init() internal initializer {
+  function __PolicyPoolComponent_init() internal onlyInitializing {
     __UUPSUpgradeable_init();
     __Pausable_init();
   }

--- a/contracts/PremiumsAccount.sol
+++ b/contracts/PremiumsAccount.sol
@@ -106,7 +106,7 @@ contract PremiumsAccount is IPremiumsAccount, Reserve {
    * @dev Initializes the PremiumsAccount (to be called by subclasses)
    */
   // solhint-disable-next-line func-name-mixedcase
-  function __PremiumsAccount_init() internal initializer {
+  function __PremiumsAccount_init() internal onlyInitializing {
     __PolicyPoolComponent_init();
     __PremiumsAccount_init_unchained();
   }
@@ -116,7 +116,7 @@ contract PremiumsAccount is IPremiumsAccount, Reserve {
    * so we don't need to do it on every repayment operation
    */
   // solhint-disable-next-line func-name-mixedcase
-  function __PremiumsAccount_init_unchained() internal initializer {
+  function __PremiumsAccount_init_unchained() internal onlyInitializing {
     /*
     _activePurePremiums = 0;
     */

--- a/contracts/RiskModule.sol
+++ b/contracts/RiskModule.sol
@@ -80,7 +80,7 @@ abstract contract RiskModule is IRiskModule, PolicyPoolComponent {
     uint256 maxPayoutPerPolicy_,
     uint256 exposureLimit_,
     address wallet_
-  ) internal initializer {
+  ) internal onlyInitializing {
     __PolicyPoolComponent_init();
     __RiskModule_init_unchained(
       name_,
@@ -102,7 +102,7 @@ abstract contract RiskModule is IRiskModule, PolicyPoolComponent {
     uint256 maxPayoutPerPolicy_,
     uint256 exposureLimit_,
     address wallet_
-  ) internal initializer {
+  ) internal onlyInitializing {
     _name = name_;
     _params = PackedParams({
       moc: 1e4,

--- a/test/test-implementation-disabled-init.js
+++ b/test/test-implementation-disabled-init.js
@@ -1,0 +1,78 @@
+const { expect } = require("chai");
+const hre = require("hardhat");
+const helpers = require("@nomicfoundation/hardhat-network-helpers");
+
+const { initCurrency, amountFunction, _W } = require("./test-utils");
+
+describe("Test Implementation contracts can't be initialized", function () {
+  const rndAddr = "0xd758af6bfc2f0908d7c5f89942be52c36a6b3cab";
+
+  async function setupFixture() {
+    const [owner] = await hre.ethers.getSigners();
+
+    const _A = amountFunction(6);
+
+    const currency = await initCurrency({ name: "Test USDC", symbol: "USDC", decimals: 6, initial_supply: _A(10000) });
+    const AccessManager = await hre.ethers.getContractFactory("AccessManager");
+    const PolicyPool = await hre.ethers.getContractFactory("PolicyPool");
+
+    // Deploy AccessManager
+    const access = await hre.upgrades.deployProxy(AccessManager, [], { kind: "uups" });
+
+    await access.deployed();
+
+    return {
+      currency,
+      _A,
+      owner,
+      access,
+      PolicyPool,
+    };
+  }
+
+  async function setupFixtureWithPool() {
+    const ret = await setupFixture();
+    const policyPool = await hre.upgrades.deployProxy(ret.PolicyPool, ["Policy NFT", "EPOL", rndAddr], {
+      constructorArgs: [ret.access.address, ret.currency.address],
+      kind: "uups",
+      unsafeAllow: ["delegatecall"],
+    });
+
+    await policyPool.deployed();
+
+    return {
+      policyPool,
+      ...ret,
+    };
+  }
+
+  it("Does not allow initialize AccessManager implementation", async () => {
+    const AccessManager = await hre.ethers.getContractFactory("AccessManager");
+    const access = await AccessManager.deploy();
+    await expect(access.initialize()).to.be.revertedWith("contract is already initialized");
+  });
+
+  it("Does not allow initialize PolicyPool implementation", async () => {
+    const { currency, access, PolicyPool } = await helpers.loadFixture(setupFixture);
+    const pool = await PolicyPool.deploy(access.address, currency.address);
+    await expect(pool.initialize("Ensuro", "EPOL", rndAddr)).to.be.revertedWith("contract is already initialized");
+  });
+
+  it("Does not allow initialize EToken implementation", async () => {
+    const { policyPool } = await helpers.loadFixture(setupFixtureWithPool);
+    const EToken = await hre.ethers.getContractFactory("EToken");
+    const etk = await EToken.deploy(policyPool.address);
+    await expect(etk.initialize("eUSD Foobar", "eUSD", _W(1), _W("0.05"))).to.be.revertedWith(
+      "contract is already initialized"
+    );
+  });
+
+  it("Does not allow initialize EToken implementation", async () => {
+    const { policyPool } = await helpers.loadFixture(setupFixtureWithPool);
+    const EToken = await hre.ethers.getContractFactory("EToken");
+    const etk = await EToken.deploy(policyPool.address);
+    await expect(etk.initialize("eUSD Foobar", "eUSD", _W(1), _W("0.05"))).to.be.revertedWith(
+      "contract is already initialized"
+    );
+  });
+});


### PR DESCRIPTION
Fix for the finding QSP-1 Uninitialized Implementation Contracts.

Work in progress.

So far we also fixed the internal initializer functions to use the `onlyInitializing` modifier instead of `initializer` that should be used only in top level function.