### PR TITLE
QSP-20 Disable repayLoan when paused

### DIFF
--- a/contracts/EToken.sol
+++ b/contracts/EToken.sol
@@ -573,7 +573,7 @@ contract EToken is Reserve, IERC20Metadata, IEToken {
     uint256 scrAmount,
     uint256 policyInterestRate,
     int256 adjustment
-  ) external override onlyBorrower {
+  ) external override onlyBorrower whenNotPaused {
     require(scrAmount <= uint256(_scr.scr), "Current SCR less than the amount you want to unlock");
     _tsScaled.updateScale(tokenInterestRate());
 

--- a/contracts/EToken.sol
+++ b/contracts/EToken.sol
@@ -673,7 +673,7 @@ contract EToken is Reserve, IERC20Metadata, IEToken {
     return amountAsked - amount;
   }
 
-  function repayLoan(uint256 amount, address onBehalfOf) external override {
+  function repayLoan(uint256 amount, address onBehalfOf) external override whenNotPaused {
     require(amount > 0, "EToken: amount should be greater than zero.");
     // Anyone can call this method, since it has to pay
     TimeScaled.ScaledAmount storage loan = _loans[onBehalfOf];


### PR DESCRIPTION
Adds the modifier to prevent repayLoan to be called when the contract is paused.