### PR TITLE
Whitelisting per operation

### DIFF
--- a/contracts/EToken.sol
+++ b/contracts/EToken.sol
@@ -647,6 +647,11 @@ contract EToken is Reserve, IERC20Metadata, IEToken {
      */
     amount = Math.min(amount, Math.min(balanceOf(provider), totalWithdrawable()));
     if (amount == 0) return 0;
+    require(
+      address(_params.whitelist) == address(0) ||
+        _params.whitelist.acceptsWithdrawal(this, provider, amount),
+      "Liquidity Provider not whitelisted"
+    );
     _burn(provider, amount);
     _updateTokenInterestRate();
     _transferTo(provider, amount);

--- a/contracts/LPManualWhitelist.sol
+++ b/contracts/LPManualWhitelist.sol
@@ -14,10 +14,37 @@ import {IEToken} from "./interfaces/IEToken.sol";
  */
 contract LPManualWhitelist is ILPWhitelist, PolicyPoolComponent {
   bytes32 public constant LP_WHITELIST_ROLE = keccak256("LP_WHITELIST_ROLE");
+  bytes32 public constant LP_WHITELIST_ADMIN_ROLE = keccak256("LP_WHITELIST_ADMIN_ROLE");
 
-  mapping(address => bool) private _whitelisted;
+  /**
+   * @dev Enum with the different options for whitelisting status
+   */
+  enum WhitelistOptions {
+    undefined,
+    whitelisted,
+    blacklisted
+  }
 
-  event LPWhitelisted(address provider, bool whitelisted);
+  /**
+   * @dev Enum with
+   */
+  enum Actions {
+    deposit,
+    withdraw,
+    sendTransfer,
+    receiveTransfer
+  }
+
+  struct WhitelistStatus {
+    WhitelistOptions deposit;
+    WhitelistOptions withdraw;
+    WhitelistOptions sendTransfer;
+    WhitelistOptions receiveTransfer;
+  }
+
+  mapping(address => WhitelistStatus) private _wlStatus;
+
+  event LPWhitelistStatusChanged(address provider, WhitelistStatus whitelisted);
 
   /// @custom:oz-upgrades-unsafe-allow constructor
   // solhint-disable-next-line no-empty-blocks
@@ -26,18 +53,37 @@ contract LPManualWhitelist is ILPWhitelist, PolicyPoolComponent {
   /**
    * @dev Initializes the Whitelist contract
    */
-  function initialize() public initializer {
+  function initialize(WhitelistStatus calldata defaultStatus) public initializer {
     __PolicyPoolComponent_init();
+    require(
+      defaultStatus.deposit != WhitelistOptions.undefined &&
+        defaultStatus.withdraw != WhitelistOptions.undefined &&
+        defaultStatus.sendTransfer != WhitelistOptions.undefined &&
+        defaultStatus.receiveTransfer != WhitelistOptions.undefined,
+      "You need to define the default status for all the operations"
+    );
+    _wlStatus[address(0)] = defaultStatus;
+    emit LPWhitelistStatusChanged(address(0), defaultStatus);
   }
 
-  function whitelistAddress(address provider, bool whitelisted)
+  function whitelistAddress(address provider, WhitelistStatus calldata newStatus)
     external
     onlyComponentRole(LP_WHITELIST_ROLE)
   {
-    if (_whitelisted[provider] != whitelisted) {
-      _whitelisted[provider] = whitelisted;
-      emit LPWhitelisted(provider, whitelisted);
-    }
+    require(provider != address(0), "You can't change the defaults");
+    _whitelistAddress(provider, newStatus);
+  }
+
+  function setWhitelistDefaults(WhitelistStatus calldata newStatus)
+    external
+    onlyComponentRole(LP_WHITELIST_ADMIN_ROLE)
+  {
+    _whitelistAddress(address(0), newStatus);
+  }
+
+  function _whitelistAddress(address provider, WhitelistStatus calldata newStatus) internal {
+    _wlStatus[provider] = newStatus;
+    emit LPWhitelistStatusChanged(provider, newStatus);
   }
 
   /**
@@ -52,16 +98,41 @@ contract LPManualWhitelist is ILPWhitelist, PolicyPoolComponent {
     address provider,
     uint256
   ) external view override returns (bool) {
-    return _whitelisted[provider];
+    WhitelistOptions wl = _wlStatus[provider].deposit;
+    if (wl == WhitelistOptions.undefined) {
+      wl = _wlStatus[address(0)].deposit;
+    }
+    return wl == WhitelistOptions.whitelisted;
+  }
+
+  function acceptsWithdrawal(
+    IEToken,
+    address provider,
+    uint256
+  ) external view override returns (bool) {
+    WhitelistOptions wl = _wlStatus[provider].withdraw;
+    if (wl == WhitelistOptions.undefined) {
+      wl = _wlStatus[address(0)].withdraw;
+    }
+    return wl == WhitelistOptions.whitelisted;
   }
 
   function acceptsTransfer(
     IEToken,
-    address,
+    address providerFrom,
     address providerTo,
     uint256
   ) external view override returns (bool) {
-    return _whitelisted[providerTo];
+    WhitelistOptions wl = _wlStatus[providerFrom].sendTransfer;
+    if (wl == WhitelistOptions.undefined) {
+      wl = _wlStatus[address(0)].sendTransfer;
+    }
+    if (wl != WhitelistOptions.whitelisted) return false;
+    wl = _wlStatus[providerTo].receiveTransfer;
+    if (wl == WhitelistOptions.undefined) {
+      wl = _wlStatus[address(0)].receiveTransfer;
+    }
+    return wl == WhitelistOptions.whitelisted;
   }
 
   /**

--- a/contracts/interfaces/ILPWhitelist.sol
+++ b/contracts/interfaces/ILPWhitelist.sol
@@ -37,4 +37,18 @@ interface ILPWhitelist {
     address providerTo,
     uint256 amount
   ) external view returns (bool);
+
+  /**
+   * @dev Indicates whether or not a liquidity provider can withdraw an eToken.
+   *
+   * @param etoken The eToken (see {EToken}) where the provider wants to withdraw money.
+   * @param provider The address of the liquidity provider (user) that wants to withdraw
+   * @param amount The amount of the withdrawal
+   * @return true if `provider` withdraw request is accepted, false if not
+   */
+  function acceptsWithdrawal(
+    IEToken etoken,
+    address provider,
+    uint256 amount
+  ) external view returns (bool);
 }

--- a/prototype/wrappers.py
+++ b/prototype/wrappers.py
@@ -904,11 +904,16 @@ class LPManualWhitelist(ETHWrapper):
     eth_contract = "LPManualWhitelist"
     proxy_kind = "uups"
 
-    initialize_args = ()
+    initialize_args = (("default_status", "tuple"),)
     constructor_args = (("pool", "address"),)
 
-    def __init__(self, pool):
-        super().__init__("owner", pool.contract)
+    ST_BLACKLISTED = 2
+    ST_WHITELISTED = 1
+    ST_UNDEFINED = 0
+
+    def __init__(self, pool,
+                 default_status=(ST_BLACKLISTED,)*4):
+        super().__init__("owner", pool.contract, default_status)
 
     whitelist_address = MethodAdapter(
         (("address", "address"), ("whitelisted", "bool")),

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -153,10 +153,8 @@ async function deployProxyContract({ saveAddr, verify, contractClass, constructo
 }
 
 function parseRole(role) {
-  if (role.startsWith("0x"))
-    return role;
-  if (role === "DEFAULT_ADMIN_ROLE")
-    return ethers.constants.HashZero;
+  if (role.startsWith("0x")) return role;
+  if (role === "DEFAULT_ADMIN_ROLE") return ethers.constants.HashZero;
   return ethers.utils.keccak256(ethers.utils.toUtf8Bytes(role));
 }
 
@@ -255,8 +253,7 @@ async function deployEToken(
     hre
   );
   const policyPool = await hre.ethers.getContractAt("PolicyPool", poolAddress);
-  if (opts.addComponent)
-    await policyPool.addComponent(contract.address, 1);
+  if (opts.addComponent) await policyPool.addComponent(contract.address, 1);
   return contract.address;
 }
 
@@ -271,8 +268,7 @@ async function deployPremiumsAccount({ poolAddress, juniorEtk, seniorEtk, ...opt
     hre
   );
   const policyPool = await hre.ethers.getContractAt("PolicyPool", poolAddress);
-  if (opts.addComponent)
-    await policyPool.addComponent(contract.address, 3);
+  if (opts.addComponent) await policyPool.addComponent(contract.address, 3);
   return contract.address;
 }
 
@@ -338,11 +334,10 @@ async function deployRiskModule(
     await rm.setParam(4, ensuroCocFee);
   }
   if (maxDuration != 24 * 365) {
-    await rm.setParam(9, ensuroCocFee);
+    await rm.setParam(9, maxDuration);
   }
   const policyPool = await hre.ethers.getContractAt("PolicyPool", poolAddress);
-  if (opts.addComponent)
-    await policyPool.addComponent(contract.address, 2);
+  if (opts.addComponent) await policyPool.addComponent(contract.address, 2);
   return contract.address;
 }
 

--- a/tests/test_policypool.py
+++ b/tests/test_policypool.py
@@ -1064,7 +1064,6 @@ def test_asset_manager(tenv):
     rm = pool.risk_modules["Roulette"]
     pool.access.grant_component_role(rm, "PRICER_ROLE", rm.owner)
     pool.access.grant_component_role(rm, "RESOLVER_ROLE", rm.owner)
-    premiums_account = rm.premiums_account
 
     USD = pool.currency
     etk = pool.etokens["eUSD1YEAR"]
@@ -1112,24 +1111,15 @@ def test_asset_manager(tenv):
         expiration=timecontrol.now + 365 * DAY // 2,
         internal_id=22,
     )
-    for_lps = policy.sr_coc
 
     etk.checkpoint()
     USD.balance_of(etk).assert_equal(_W(1500) + policy.sr_coc)
     etk.balance_of("LP1").assert_equal(lp1_balance)
-    # pool.get_investable().assert_equal(policy.pure_premium)
-    # etk.get_investable().assert_equal(lp1_balance)
 
     timecontrol.fast_forward(365 * DAY // 2 - 60)
-    # pool.get_investable().assert_equal(policy.pure_premium)
-    # etk.get_investable().assert_equal(lp1_balance + for_lps, decimals=2)
 
-    # pool_share = _W(policy.pure_premium) // asset_manager.total_investable()
-    # etk_share = etk.get_investable() // asset_manager.total_investable()
     etk.checkpoint()
 
-    # premiums_account.won_pure_premiums.assert_equal(_W(8500) * _W("0.025") * pool_share)
-    # etk.balance_of("LP1").assert_equal(lp1_balance + for_lps + _W(8500) * _W("0.025") * etk_share, decimals=2)
     rm.resolve_policy(policy.id, True)
     assert USD.balance_of(etk) == _W(1500)  # balance back to middle
     vault.total_assets().assert_equal(
@@ -1390,7 +1380,7 @@ def test_distribute_negative_earnings_full_capital_from_etokens(tenv):
     )
     lp1_balance = etk.balance_of("LP1")
 
-    policy_2 = rm.new_policy(
+    rm.new_policy(
         payout=_W(5),
         premium=_W("0.75"),
         on_behalf_of="CUST1",
@@ -1526,7 +1516,19 @@ def test_lp_whitelist(tenv):
     # Without whitelist, anyone can deposit
     _deposit(pool, "eUSD1YEAR", "LP1", _W(1000))
 
-    whitelist = tenv.module.LPManualWhitelist(pool=pool)
+    WL = tenv.module.LPManualWhitelist
+
+    all_blacklisted = (WL.ST_BLACKLISTED,) * 4
+    all_whitelisted = (WL.ST_WHITELISTED,) * 4
+
+    previous_behaviour = (
+        WL.ST_BLACKLISTED,  # deposit requires explicit WL
+        WL.ST_WHITELISTED,  # withdrawal is open
+        WL.ST_WHITELISTED,  # sending transfers is open
+        WL.ST_BLACKLISTED,  # receiving transfers requires explicit WL
+    )
+
+    whitelist = tenv.module.LPManualWhitelist(pool=pool, default_status=previous_behaviour)
 
     with pool.access.as_("johndoe"), pytest.raises(RevertError, match="AccessControl"):
         etk.set_whitelist(whitelist)
@@ -1542,15 +1544,15 @@ def test_lp_whitelist(tenv):
 
     # Whitelisting requires permission
     with whitelist.as_("johndoe"), pytest.raises(RevertError, match="AccessControl"):
-        whitelist.whitelist_address("LP2", True)
+        whitelist.whitelist_address("LP2", all_whitelisted)
 
     pool.access.grant_component_role(whitelist, "LP_WHITELIST_ROLE", "amlcompliance")
     with whitelist.as_("amlcompliance"):
-        whitelist.whitelist_address("LP2", True)
+        whitelist.whitelist_address("LP2", all_whitelisted)
 
-    # Try to whitelist the same address again
+    # Try to whitelist the same address again - Probably this no longer needed
     with whitelist.as_("amlcompliance"):
-        whitelist.whitelist_address("LP2", True)
+        whitelist.whitelist_address("LP2", all_whitelisted)
 
     assert pool.deposit("eUSD1YEAR", "LP2", _W(2000)) == _W(2000)
 
@@ -1559,7 +1561,7 @@ def test_lp_whitelist(tenv):
         etk.transfer("LP2", "LP3", _W(500))
 
     with whitelist.as_("amlcompliance"):
-        whitelist.whitelist_address("LP3", True)
+        whitelist.whitelist_address("LP3", all_whitelisted)
     etk.transfer("LP2", "LP3", _W(500))
 
     etk.balance_of("LP2").assert_equal(_W(1500))
@@ -1570,11 +1572,18 @@ def test_lp_whitelist(tenv):
 
     # De-whitelist can't deposit anymore
     with whitelist.as_("amlcompliance"):
-        whitelist.whitelist_address("LP2", False)
+        whitelist.whitelist_address("LP2", all_blacklisted)
     with pytest.raises(RevertError, match="Liquidity Provider not whitelisted"):
         pool.deposit("eUSD1YEAR", "LP2", _W(1000))
 
-    # But can withdraw
+    # Can't withdraw if all_blacklisted
+    with pytest.raises(RevertError, match="Liquidity Provider not whitelisted"):
+        pool.withdraw("eUSD1YEAR", "LP2", _W(300)).assert_equal(_W(300))
+
+    # But can withdraw if using defaults
+    with whitelist.as_("amlcompliance"):
+        whitelist.whitelist_address("LP2", previous_behaviour)
+
     pool.withdraw("eUSD1YEAR", "LP2", _W(300)).assert_equal(_W(300))
 
 


### PR DESCRIPTION
Previously we couldn't blacklist the withdrawals. Now we added another check in the eToken calling `acceptsWithdrawal`.

In the implementation of the LPManualWhitelist we added more granularity. Now for each LP we can specify different whitelisting status for each of the four operations: deposit, withdraw, sending transfers, receiving transfers.

The LPManualWhitelist also receives the default behaviours for each of the operations if the LP doesn't have anything defined.