### PR TITLE
Revert on exceeded withdraw

### DIFF
--- a/contracts/EToken.sol
+++ b/contracts/EToken.sol
@@ -675,8 +675,10 @@ contract EToken is Reserve, IERC20Metadata, IEToken {
      * The only limit for withdraws is the `totalWithdrawable()` function, that's affected by the relation between the
      * scr and the totalSupply.
      */
-    amount = Math.min(amount, Math.min(balanceOf(provider), totalWithdrawable()));
+    uint256 maxWithdraw = Math.min(balanceOf(provider), totalWithdrawable());
+    if (amount == type(uint256).max) amount = maxWithdraw;
     if (amount == 0) return 0;
+    require(amount <= maxWithdraw, "amount > max withdrawable");
     require(
       address(_params.whitelist) == address(0) ||
         _params.whitelist.acceptsWithdrawal(this, provider, amount),

--- a/prototype/ensuro.py
+++ b/prototype/ensuro.py
@@ -682,7 +682,7 @@ class EToken(ReserveMixin, ERC20Token):
             amount = max_withdraw
         if amount == 0:
             return Wad(0)
-        require(amount < max_withdraw, "amount > max withdrawable")
+        require(amount <= max_withdraw, "amount > max withdrawable")
 
         require(
             self.whitelist is None

--- a/prototype/ensuro.py
+++ b/prototype/ensuro.py
@@ -677,14 +677,12 @@ class EToken(ReserveMixin, ERC20Token):
     @external
     def withdraw(self, provider, amount):
         self._update_current_scale()
-        balance = self.balance_of(provider)
-        if balance == 0:
-            return Wad(0)
-        if amount is None or amount > balance:
-            amount = balance
-        amount = min(amount, self.total_withdrawable())
+        max_withdraw = min(self.balance_of(provider), self.total_withdrawable())
+        if amount is None:
+            amount = max_withdraw
         if amount == 0:
             return Wad(0)
+        require(amount < max_withdraw, "amount > max withdrawable")
 
         require(
             self.whitelist is None


### PR DESCRIPTION
Change in the withdraw function to revert if the amount required is more than the amount available to withdraw (unless MAX_UINT is sent as amount, in that case it will withdraw as much as possible).

Code changes only. TODO: fix the tests