### PR TITLE
Loss Propagation Limits

### DIFF
--- a/contracts/EToken.sol
+++ b/contracts/EToken.sol
@@ -511,11 +511,12 @@ contract EToken is Reserve, IERC20Metadata, IEToken {
     uint256 totalSupply_ = this.totalSupply();
     if (totalSupply_ == 0) _scr.tokenInterestRate = 0;
     else {
-      uint256 newTokenInterestRate = uint256(_scr.interestRate)
-        .wadMul(uint256(_scr.scr))
-        .wadDiv(totalSupply_);
-      _scr.tokenInterestRate = (newTokenInterestRate > type(uint64).max) ? type(uint64).max :
-        newTokenInterestRate.toUint64();
+      uint256 newTokenInterestRate = uint256(_scr.interestRate).wadMul(uint256(_scr.scr)).wadDiv(
+        totalSupply_
+      );
+      _scr.tokenInterestRate = (newTokenInterestRate > type(uint64).max)
+        ? type(uint64).max
+        : newTokenInterestRate.toUint64();
       // This is not the mathematically correct value, but the max we can set. The actual value of the total supply
       // will be adjusted when the policies expire or are resolved and the SCR is unlocked.
     }
@@ -716,15 +717,15 @@ contract EToken is Reserve, IERC20Metadata, IEToken {
     return totalSupply() - _tsScaled.minValue(); // Min value accepted by _tsScaled
   }
 
-  function internalLoan(
-    uint256 amount,
-    address receiver
-  ) external override onlyBorrower whenNotPaused returns (uint256) {
+  function internalLoan(uint256 amount, address receiver)
+    external
+    override
+    onlyBorrower
+    whenNotPaused
+    returns (uint256)
+  {
     uint256 amountAsked = amount;
-    amount = Math.min(
-      Math.min(amount, totalSupply()),
-      maxNegativeAdjustment()
-    );
+    amount = Math.min(Math.min(amount, totalSupply()), maxNegativeAdjustment());
     if (amount == 0) return amountAsked;
     TimeScaled.ScaledAmount storage loan = _loans[_msgSender()];
     loan.add(amount, internalLoanInterestRate());

--- a/contracts/EToken.sol
+++ b/contracts/EToken.sol
@@ -725,7 +725,7 @@ contract EToken is Reserve, IERC20Metadata, IEToken {
     returns (uint256)
   {
     uint256 amountAsked = amount;
-    amount = Math.min(Math.min(amount, totalSupply()), maxNegativeAdjustment());
+    amount = Math.min(amount, maxNegativeAdjustment());
     if (amount == 0) return amountAsked;
     TimeScaled.ScaledAmount storage loan = _loans[_msgSender()];
     loan.add(amount, internalLoanInterestRate());

--- a/contracts/EToken.sol
+++ b/contracts/EToken.sol
@@ -511,10 +511,13 @@ contract EToken is Reserve, IERC20Metadata, IEToken {
     uint256 totalSupply_ = this.totalSupply();
     if (totalSupply_ == 0) _scr.tokenInterestRate = 0;
     else {
-      _scr.tokenInterestRate = uint256(_scr.interestRate)
+      uint256 newTokenInterestRate = uint256(_scr.interestRate)
         .wadMul(uint256(_scr.scr))
-        .wadDiv(totalSupply_)
-        .toUint64();
+        .wadDiv(totalSupply_);
+      _scr.tokenInterestRate = (newTokenInterestRate > type(uint64).max) ? type(uint64).max :
+        newTokenInterestRate.toUint64();
+      // This is not the mathematically correct value, but the max we can set. The actual value of the total supply
+      // will be adjusted when the policies expire or are resolved and the SCR is unlocked.
     }
   }
 
@@ -705,15 +708,22 @@ contract EToken is Reserve, IERC20Metadata, IEToken {
     emit InternalBorrowerRemoved(borrower, defaultedDebt);
   }
 
+  /**
+   * @dev Returns the maximum negative adjustment (discrete loss) the eToken can accept without breaking consistency.
+   *      The limit comes from limits in the internal scale that takes scaledTotalSupply() to totalSupply()
+   */
+  function maxNegativeAdjustment() public view returns (uint256) {
+    return totalSupply() - _tsScaled.minValue(); // Min value accepted by _tsScaled
+  }
+
   function internalLoan(
     uint256 amount,
-    address receiver,
-    bool fromAvailable
+    address receiver
   ) external override onlyBorrower whenNotPaused returns (uint256) {
     uint256 amountAsked = amount;
     amount = Math.min(
-      Math.min(amount, fromAvailable ? fundsAvailable() : totalSupply()),
-      _tsScaled.maxNegativeAdjustment(tokenInterestRate())
+      Math.min(amount, totalSupply()),
+      maxNegativeAdjustment()
     );
     if (amount == 0) return amountAsked;
     TimeScaled.ScaledAmount storage loan = _loans[_msgSender()];

--- a/contracts/LPManualWhitelist.sol
+++ b/contracts/LPManualWhitelist.sol
@@ -43,7 +43,7 @@ contract LPManualWhitelist is ILPWhitelist, PolicyPoolComponent {
   /**
    * @dev Initializes the Whitelist contract
    */
-  function initialize(WhitelistStatus calldata defaultStatus) public initializer {
+  function initialize(WhitelistStatus calldata defaultStatus) public virtual initializer {
     __LPManualWhitelist_init(defaultStatus);
   }
 

--- a/contracts/PremiumsAccount.sol
+++ b/contracts/PremiumsAccount.sol
@@ -329,7 +329,7 @@ contract PremiumsAccount is IPremiumsAccount, Reserve {
    * @param newLimitSr     The new limit to be set for the loans taken from the Senior eToken.
                            If newLimitSr == MAX_UINT, it's ignored. If == 0, means the loans are unbounded.
    */
-  function setLoanLimit(uint256 newLimitJr, uint256 newLimitSr)
+  function setLoanLimits(uint256 newLimitJr, uint256 newLimitSr)
     external
     onlyComponentRole(LEVEL2_ROLE)
   {

--- a/contracts/PremiumsAccount.sol
+++ b/contracts/PremiumsAccount.sol
@@ -335,18 +335,12 @@ contract PremiumsAccount is IPremiumsAccount, Reserve {
   {
     if (newLimitJr != type(uint256).max) {
       _params.jrLoanLimit = _toZeroDecimals(newLimitJr);
-      require(
-        _toAmount(_params.jrLoanLimit) == newLimitJr,
-        "Validation: no decimals allowed"
-      );
+      require(_toAmount(_params.jrLoanLimit) == newLimitJr, "Validation: no decimals allowed");
       _parameterChanged(IAccessManager.GovernanceActions.setJrLoanLimit, newLimitJr, false);
     }
     if (newLimitSr != type(uint256).max) {
       _params.srLoanLimit = _toZeroDecimals(newLimitSr);
-      require(
-        _toAmount(_params.srLoanLimit) == newLimitSr,
-        "Validation: no decimals allowed"
-      );
+      require(_toAmount(_params.srLoanLimit) == newLimitSr, "Validation: no decimals allowed");
       _parameterChanged(IAccessManager.GovernanceActions.setSrLoanLimit, newLimitSr, false);
     }
   }

--- a/contracts/RiskModule.sol
+++ b/contracts/RiskModule.sol
@@ -185,12 +185,12 @@ abstract contract RiskModule is IRiskModule, PolicyPoolComponent {
 
   // solhint-disable-next-line func-name-mixedcase
   function _XtoAmount(uint8 decimals, uint32 value) internal view returns (uint256) {
-    // X decimals to Wad (18 decimals)
+    // X decimals to currency decimals (6 for USDC)
     return uint256(value) * 10**(currency().decimals() - decimals);
   }
 
   function _amountToX(uint8 decimals, uint256 value) internal view returns (uint32) {
-    // Wad to X decimals
+    // currency decimals to X decimals (assuming X < currency decimals)
     return (value / 10**(currency().decimals() - decimals)).toUint32();
   }
 

--- a/contracts/TimeScaled.sol
+++ b/contracts/TimeScaled.sol
@@ -125,14 +125,11 @@ library TimeScaled {
     require(scaledAmount.scale >= MIN_SCALE, "Scale too small, can lead to rounding errors");
   }
 
-  function maxNegativeAdjustment(ScaledAmount storage scaledAmount, uint256 interestRate)
+  function minValue(ScaledAmount storage scaledAmount)
     internal
     view
     returns (uint256)
   {
-    uint256 ts = getScaledAmount(scaledAmount, interestRate);
-    uint256 minTs = uint256(scaledAmount.amount).wadToRay().rayMul(MIN_SCALE).rayToWad();
-    if (ts > minTs) return ts - minTs;
-    else return 0;
+    return uint256(scaledAmount.amount).wadToRay().rayMul(MIN_SCALE).rayToWad();
   }
 }

--- a/contracts/TimeScaled.sol
+++ b/contracts/TimeScaled.sol
@@ -125,11 +125,7 @@ library TimeScaled {
     require(scaledAmount.scale >= MIN_SCALE, "Scale too small, can lead to rounding errors");
   }
 
-  function minValue(ScaledAmount storage scaledAmount)
-    internal
-    view
-    returns (uint256)
-  {
+  function minValue(ScaledAmount storage scaledAmount) internal view returns (uint256) {
     return uint256(scaledAmount.amount).wadToRay().rayMul(MIN_SCALE).rayToWad();
   }
 }

--- a/contracts/interfaces/IAccessManager.sol
+++ b/contracts/interfaces/IAccessManager.sol
@@ -52,10 +52,10 @@ interface IAccessManager is IAccessControlUpgradeable {
     // PremiumsAccount Governance Actions
     setDeficitRatio,
     setDeficitRatioWithAdjustment,
-    paFiller1,
-    paFiller2,
-    paFiller3,
-    paFiller4,
+    setJrLoanLimit,
+    setSrLoanLimit,
+    paFiller3, // Reserve space for future PremiumsAccount actions
+    paFiller4, // Reserve space for future PremiumsAccount actions
     // AssetManager Governance Actions
     setLiquidityMin,
     setLiquidityMiddle,

--- a/contracts/interfaces/IEToken.sol
+++ b/contracts/interfaces/IEToken.sol
@@ -152,14 +152,11 @@ interface IEToken is IERC20 {
    *
    * @param amount The amount required
    * @param receiver The received of the funds lent. This is usually the policyholder if the loan is used for a payout.
-   * @param fromAvailable If `true`, the funds that can be lent are only the available ones, i.e., excluding the funds
-   * locked as `scr()`. If `false`, all the `totalSupply()` is available to be lent.
    * @return Returns the amount that wasn't able to fulfil. `amount - lent`
    */
   function internalLoan(
     uint256 amount,
-    address receiver,
-    bool fromAvailable
+    address receiver
   ) external returns (uint256);
 
   /**

--- a/contracts/interfaces/IEToken.sol
+++ b/contracts/interfaces/IEToken.sol
@@ -154,10 +154,7 @@ interface IEToken is IERC20 {
    * @param receiver The received of the funds lent. This is usually the policyholder if the loan is used for a payout.
    * @return Returns the amount that wasn't able to fulfil. `amount - lent`
    */
-  function internalLoan(
-    uint256 amount,
-    address receiver
-  ) external returns (uint256);
+  function internalLoan(uint256 amount, address receiver) external returns (uint256);
 
   /**
    * @dev Repays a loan taken with `internalLoan`.

--- a/prototype/wrappers.py
+++ b/prototype/wrappers.py
@@ -825,6 +825,11 @@ class PremiumsAccount(ReserveMixin, ETHWrapper):
     policy_created_ = MethodAdapter((("policy", "tuple"),))
     policy_expired_ = MethodAdapter((("policy", "tuple"),))
     set_deficit_ratio = MethodAdapter((("new_ratio", "wad"), ("adjustment", "bool")))
+    set_loan_limits = MethodAdapter((("new_jr_loan_limit", "amount"), ("new_sr_loan_limit", "amount")))
+
+    jr_loan_limit = MethodAdapter((), "amount", is_property=True)
+    sr_loan_limit = MethodAdapter((), "amount", is_property=True)
+
     policy_resolved_with_payout_ = MethodAdapter(
         (("customer", "address"), ("policy", "tuple"), ("payout", "amount"))
     )

--- a/prototype/wrappers.py
+++ b/prototype/wrappers.py
@@ -224,17 +224,18 @@ class EToken(ReserveMixin, IERC20):
         else:
             return Wad(0)
 
+    max_negative_adjustment = MethodAdapter((), "amount")
+
     internal_loan_ = MethodAdapter(
         (
             ("borrower", "msg.sender"),
             ("amount", "amount"),
             ("receiver", "address"),
-            ("from_available", "bool"),
         )
     )
 
-    def internal_loan(self, borrower, amount, receiver, from_available=True):
-        receipt = self.internal_loan_(borrower, amount, receiver, from_available)
+    def internal_loan(self, borrower, amount, receiver):
+        receipt = self.internal_loan_(borrower, amount, receiver)
         if "InternalLoan" in receipt.events:
             evt = receipt.events["InternalLoan"]
             return Wad(evt["amountAsked"]) - Wad(evt["value"])

--- a/test/test-supports-interface.js
+++ b/test/test-supports-interface.js
@@ -43,7 +43,7 @@ describe("Supports interface implementation", function () {
       IERC20Metadata: "0xa219a025",
       IERC721: "0x80ac58cd",
       IAccessControl: "0x7965db0b",
-      IEToken: "0x027466bc",
+      IEToken: "0x90770621",
       IPolicyPool: "0x3234fad6",
       IPolicyPoolComponent: "0x4cea22a4",
       IRiskModule: "0xda40804f",

--- a/tests/test_etoken.py
+++ b/tests/test_etoken.py
@@ -416,13 +416,17 @@ def test_internal_loan(tenv):
     etk.funds_available.assert_equal(_W(400) + _W(600 * 0.04 * 7 / 365))
 
     funds_available = etk.funds_available
+    total_supply = etk.total_supply()
+    max_negative_adjustment = etk.max_negative_adjustment()
+
+    assert max_negative_adjustment < total_supply
 
     assert funds_available < _W(401)
 
     with etk.thru(pa):
-        not_lended = etk.internal_loan(pa, _W(401), "CUST1")
-        not_lended.assert_equal(_W(401) - funds_available)
-        lended = _W(401) - not_lended
+        not_lended = etk.internal_loan(pa, _W(1001), "CUST1")
+        not_lended.assert_equal(_W(1001) - max_negative_adjustment)
+        lended = _W(1001) - not_lended
         assert tenv.currency.balance_of("CUST1") == lended
         assert etk.get_loan(pa) == lended
 


### PR DESCRIPTION
Adds two new parameters to PremiumsAccount to be able to specify the limits on the loans taken from the Junior and Senior eToken. By default the loans are unbounded.

These parameters allow to define a hard limit on the propagation of losses to the eTokens, mainly to the senior one.

This could have been implemented on eToken side, but that would require a major refactoring, so we keep that for next versions.