### PR TITLE
Parametrized tests using 6 or 18 decimals

### DIFF
--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -52,8 +52,12 @@ jobs:
       - run: |
           RELEASE_TAG="${{ github.event.inputs.tag }}"
           if [ -z "$RELEASE_TAG" ]; then
-            # No manual input, we must be running on a tag
-            RELEASE_TAG=latest
+            if [[ "$SEMVER" == *"-beta"* ]]; then
+              RELEASE_TAG=beta
+            else
+              # No manual input, we must be running on a tag
+              RELEASE_TAG=latest
+            fi
           fi
           npm publish --tag "$RELEASE_TAG"
         working-directory: ./build/npm-package


### PR DESCRIPTION
Change done on RiskModule tests. The same suite is run with 6 and 18 decimals.

With these tests I verified the tweak checks on the exposure limit work well (the problem was that LEVEL1 is required to increase the exposure limit).