### PR TITLE
Migration contract for 2.0 whitelist

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -4,6 +4,6 @@ module.exports = {
   //   instrumentedDir: path.join(process.cwd(), "instrumented"),
   //   client: client,
   port: 8545,
-  skipFiles: ["dependencies/", "mocks/"],
+  skipFiles: ["dependencies/", "mocks/", "migration/"],
   //   logger: console,
 };

--- a/contracts/migration/LPManualWhitelistV20.sol
+++ b/contracts/migration/LPManualWhitelistV20.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.16;
+
+import {IPolicyPool} from "../interfaces/IPolicyPool.sol";
+import {PolicyPoolComponent} from "../PolicyPoolComponent.sol";
+import {ILPWhitelist} from "../interfaces/ILPWhitelist.sol";
+import {IEToken} from "../interfaces/IEToken.sol";
+
+/**
+ * @title Manual Whitelisting contract - V2.0
+ * @dev LP addresses are whitelisted (and un-whitelisted) manually with transactions by user with given role
+ * @custom:security-contact security@ensuro.co
+ * @author Ensuro
+ */
+abstract contract LPManualWhitelistV20 is ILPWhitelist, PolicyPoolComponent {
+  bytes32 public constant LP_WHITELIST_ROLE = keccak256("LP_WHITELIST_ROLE");
+
+  mapping(address => bool) private _whitelisted;
+
+  event LPWhitelisted(address provider, bool whitelisted);
+
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  // solhint-disable-next-line no-empty-blocks
+  constructor(IPolicyPool policyPool_) PolicyPoolComponent(policyPool_) {}
+
+  /**
+   * @dev Initializes the Whitelist contract
+   */
+  function initialize() public initializer {
+    __PolicyPoolComponent_init();
+  }
+
+  function whitelistAddress(address provider, bool whitelisted)
+    external
+    onlyComponentRole(LP_WHITELIST_ROLE)
+  {
+    if (_whitelisted[provider] != whitelisted) {
+      _whitelisted[provider] = whitelisted;
+      emit LPWhitelisted(provider, whitelisted);
+    }
+  }
+
+  /**
+   * @dev See {IERC165-supportsInterface}.
+   */
+  function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+    return super.supportsInterface(interfaceId) || interfaceId == type(ILPWhitelist).interfaceId;
+  }
+
+  function acceptsDeposit(
+    IEToken,
+    address provider,
+    uint256
+  ) external view override returns (bool) {
+    return _whitelisted[provider];
+  }
+
+  function acceptsTransfer(
+    IEToken,
+    address,
+    address providerTo,
+    uint256
+  ) external view override returns (bool) {
+    return _whitelisted[providerTo];
+  }
+
+  /**
+   * @dev This empty reserved space is put in place to allow future versions to add new
+   * variables without shifting down storage in the inheritance chain.
+   * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+   */
+  uint256[49] private __gap;
+}

--- a/contracts/migration/LPManualWhitelistV20Upgraded.sol
+++ b/contracts/migration/LPManualWhitelistV20Upgraded.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.16;
+
+import {IPolicyPool} from "../interfaces/IPolicyPool.sol";
+import {IEToken} from "../interfaces/IEToken.sol";
+import {LPManualWhitelistV20} from "./LPManualWhitelistV20.sol";
+
+/**
+ * @title Manual Whitelisting contract - Migration from 2.0 to 2.1
+ * @dev Contract with the same storage as the LPManualWhitelist 2.0 but that complies with the new interface
+ *      useful for update in place of the current whitelist
+ * @custom:security-contact security@ensuro.co
+ * @author Ensuro
+ */
+contract LPManualWhitelistV20Upgraded is LPManualWhitelistV20 {
+  constructor(IPolicyPool policyPool_) LPManualWhitelistV20(policyPool_) {}
+
+  function acceptsWithdrawal(
+    IEToken etk,
+    address provider,
+    uint256 amount
+  ) external view override returns (bool) {
+    return this.acceptsDeposit(etk, provider, amount);
+  }
+}


### PR DESCRIPTION
Migration contract that will be used to upgrade the current 2.0 whitelist. This just implements the `acceptsWithdrawal` endpoint using acceptsDeposit.

No tests included here, it will be tested in the deployment repository.

This contract will be used only for a few days until a brand new whitelist contract is deployed and the whitelisted users are migrated.