### PR TITLE
New internal function _newPolicyWithCustomParams

### DIFF
--- a/contracts/RiskModule.sol
+++ b/contracts/RiskModule.sol
@@ -278,15 +278,19 @@ abstract contract RiskModule is IRiskModule, PolicyPoolComponent {
   }
 
   function params() public view virtual override returns (Params memory ret) {
+    return _unpackParams(_params);
+  }
+
+  function _unpackParams(PackedParams storage params_) internal view returns (Params memory ret) {
     return
       Params({
-        moc: _4toWad(_params.moc),
-        jrCollRatio: _4toWad(_params.jrCollRatio),
-        collRatio: _4toWad(_params.collRatio),
-        ensuroPpFee: _4toWad(_params.ensuroPpFee),
-        ensuroCocFee: _4toWad(_params.ensuroCocFee),
-        jrRoc: _4toWad(_params.jrRoc),
-        srRoc: _4toWad(_params.srRoc)
+        moc: _4toWad(params_.moc),
+        jrCollRatio: _4toWad(params_.jrCollRatio),
+        collRatio: _4toWad(params_.collRatio),
+        ensuroPpFee: _4toWad(params_.ensuroPpFee),
+        ensuroCocFee: _4toWad(params_.ensuroCocFee),
+        jrRoc: _4toWad(params_.jrRoc),
+        srRoc: _4toWad(params_.srRoc)
       });
   }
 

--- a/contracts/RiskModule.sol
+++ b/contracts/RiskModule.sol
@@ -144,28 +144,32 @@ abstract contract RiskModule is IRiskModule, PolicyPoolComponent {
   }
 
   // runs validation on RiskModule parameters
-  function _validateParameters() internal view override {
-    require(_params.jrCollRatio <= HUNDRED_PERCENT, "Validation: jrCollRatio must be <=1");
-    require(
-      _params.collRatio <= HUNDRED_PERCENT && _params.collRatio > 0,
-      "Validation: collRatio must be <=1"
-    );
-    require(_params.collRatio >= _params.jrCollRatio, "Validation: collRatio >= jrCollRatio");
-    require(_params.moc <= MAX_MOC && _params.moc >= MIN_MOC, "Validation: moc must be [0.5, 4]");
-    require(_params.ensuroPpFee <= HUNDRED_PERCENT, "Validation: ensuroPpFee must be <= 1");
-    require(_params.ensuroCocFee <= HUNDRED_PERCENT, "Validation: ensuroCocFee must be <= 1");
-    require(_params.srRoc <= HUNDRED_PERCENT, "Validation: srRoc must be <= 1 (100%)");
-    require(_params.jrRoc <= HUNDRED_PERCENT, "Validation: jrRoc must be <= 1 (100%)");
+  function _validateParameters() internal view virtual override {
     // _maxPayoutPerPolicy no limits
     require(
       exposureLimit() >= _activeExposure,
       "Validation: exposureLimit can't be less than actual activeExposure"
     );
+    require(_wallet != address(0), "Validation: Wallet can't be zero address");
+    _validatePackedParams(_params);
+  }
+
+  function _validatePackedParams(PackedParams storage params_) internal view {
+    require(params_.jrCollRatio <= HUNDRED_PERCENT, "Validation: jrCollRatio must be <=1");
     require(
-      _params.exposureLimit > 0 && _params.maxPayoutPerPolicy > 0,
+      params_.collRatio <= HUNDRED_PERCENT && params_.collRatio > 0,
+      "Validation: collRatio must be <=1"
+    );
+    require(params_.collRatio >= params_.jrCollRatio, "Validation: collRatio >= jrCollRatio");
+    require(params_.moc <= MAX_MOC && params_.moc >= MIN_MOC, "Validation: moc must be [0.5, 4]");
+    require(params_.ensuroPpFee <= HUNDRED_PERCENT, "Validation: ensuroPpFee must be <= 1");
+    require(params_.ensuroCocFee <= HUNDRED_PERCENT, "Validation: ensuroCocFee must be <= 1");
+    require(params_.srRoc <= HUNDRED_PERCENT, "Validation: srRoc must be <= 1 (100%)");
+    require(params_.jrRoc <= HUNDRED_PERCENT, "Validation: jrRoc must be <= 1 (100%)");
+    require(
+      params_.exposureLimit > 0 && params_.maxPayoutPerPolicy > 0,
       "Exposure and MaxPayout must be >0"
     );
-    require(_wallet != address(0), "Validation: Wallet can't be zero address");
   }
 
   function name() public view override returns (string memory) {
@@ -273,7 +277,7 @@ abstract contract RiskModule is IRiskModule, PolicyPoolComponent {
     );
   }
 
-  function params() public view override returns (Params memory ret) {
+  function params() public view virtual override returns (Params memory ret) {
     return
       Params({
         moc: _4toWad(_params.moc),
@@ -296,7 +300,7 @@ abstract contract RiskModule is IRiskModule, PolicyPoolComponent {
     uint256 payout,
     uint256 lossProb,
     uint40 expiration
-  ) public view returns (uint256) {
+  ) public view virtual returns (uint256) {
     return _getMinimumPremium(payout, lossProb, expiration, params());
   }
 

--- a/contracts/RiskModule.sol
+++ b/contracts/RiskModule.sol
@@ -342,6 +342,66 @@ abstract contract RiskModule is IRiskModule, PolicyPoolComponent {
     address onBehalfOf,
     uint96 internalId
   ) internal whenNotPaused returns (Policy.PolicyData memory) {
+    return
+      _newPolicyWithParams(
+        payout,
+        premium,
+        lossProb,
+        expiration,
+        payer,
+        onBehalfOf,
+        internalId,
+        params()
+      );
+  }
+
+  /**
+   * @dev Called from child contracts to create policies (after they validated the pricing), receives custom params
+   *
+   * @param payout The exposure (maximum payout) of the policy
+   * @param premium The premium that will be paid by the policyHolder
+   * @param lossProb The probability of having to pay the maximum payout (wad)
+   * @param payer The account that pays for the premium
+   * @param expiration The expiration of the policy (timestamp)
+   * @param onBehalfOf The policy holder
+   * @param internalId An id that's unique within this module and it will be used to identify the policy
+   */
+  function _newPolicyCustomParams(
+    uint256 payout,
+    uint256 premium,
+    uint256 lossProb,
+    uint40 expiration,
+    address payer,
+    address onBehalfOf,
+    uint96 internalId,
+    Params memory params_
+  ) internal whenNotPaused returns (Policy.PolicyData memory) {
+    return
+      _newPolicyWithParams(
+        payout,
+        premium,
+        lossProb,
+        expiration,
+        payer,
+        onBehalfOf,
+        internalId,
+        params_
+      );
+  }
+
+  /**
+   * @dev Internal method without whenNotPaused, MUST be called from other function that has this modifier
+   */
+  function _newPolicyWithParams(
+    uint256 payout,
+    uint256 premium,
+    uint256 lossProb,
+    uint40 expiration,
+    address payer,
+    address onBehalfOf,
+    uint96 internalId,
+    Params memory params_
+  ) internal returns (Policy.PolicyData memory) {
     if (premium == type(uint256).max) {
       premium = getMinimumPremium(payout, lossProb, expiration);
     }
@@ -361,7 +421,7 @@ abstract contract RiskModule is IRiskModule, PolicyPoolComponent {
     require(payout <= maxPayoutPerPolicy(), "RiskModule: Payout is more than maximum per policy");
     Policy.PolicyData memory policy = Policy.initialize(
       this,
-      params(),
+      params_,
       premium,
       payout,
       lossProb,

--- a/contracts/RiskModule.sol
+++ b/contracts/RiskModule.sol
@@ -297,7 +297,15 @@ abstract contract RiskModule is IRiskModule, PolicyPoolComponent {
     uint256 lossProb,
     uint40 expiration
   ) public view returns (uint256) {
-    Params memory p = params();
+    return _getMinimumPremium(payout, lossProb, expiration, params());
+  }
+
+  function _getMinimumPremium(
+    uint256 payout,
+    uint256 lossProb,
+    uint40 expiration,
+    Params memory p
+  ) internal view returns (uint256) {
     uint256 purePremium = payout.wadMul(lossProb.wadMul(p.moc));
     uint256 jrScr = payout.wadMul(p.jrCollRatio);
     if (jrScr > purePremium) {


### PR DESCRIPTION
This can be called from risk modules that have different parameters for each policy, for example with levels of collateralization depending on the loss prob.