### PR TITLE
Refactor PremiumsAccount - Repayments on-demand

### DIFF
--- a/contracts/PremiumsAccount.sol
+++ b/contracts/PremiumsAccount.sol
@@ -190,7 +190,7 @@ contract PremiumsAccount is IPremiumsAccount, Reserve {
    *   loans to cover asset losses.
    */
   function _assetEarnings(int256 earningsOrLosses) internal override {
-    if (earningsOrLosses > 0) {
+    if (earningsOrLosses >= 0) {
       _storePurePremiumWon(uint256(earningsOrLosses));
     } else {
       require(_payFromPremiums(-earningsOrLosses) == 0, "Losses can't exceed maxDeficit");
@@ -430,7 +430,6 @@ contract PremiumsAccount is IPremiumsAccount, Reserve {
    * @param purePremiumWon The amount earned
    */
   function _storePurePremiumWon(uint256 purePremiumWon) internal {
-    if (purePremiumWon == 0) return;
     _surplus += int256(purePremiumWon);
   }
 

--- a/prototype/ensuro.py
+++ b/prototype/ensuro.py
@@ -979,10 +979,6 @@ class PremiumsAccount(ReserveMixin, AccessControlContract):
 
     def asset_earnings(self, amount):
         if amount >= 0:
-            if self.senior_etk:
-                amount = self._repay_loan(amount, self.senior_etk)
-            if self.junior_etk:
-                amount = self._repay_loan(amount, self.junior_etk)
             self._store_pure_premium_won(amount)
         else:
             left = self._pay_from_premiums(-amount)
@@ -991,12 +987,7 @@ class PremiumsAccount(ReserveMixin, AccessControlContract):
     @external
     def receive_grant(self, sender, amount):
         self.currency.transfer_from(self.contract_id, sender, self.contract_id, amount)
-        pure_premium_won = amount
-        if self.senior_etk:
-            pure_premium_won = self._repay_loan(pure_premium_won, self.senior_etk)
-        if self.junior_etk:
-            pure_premium_won = self._repay_loan(pure_premium_won, self.junior_etk)
-        self._store_pure_premium_won(pure_premium_won)
+        self._store_pure_premium_won(amount)
 
     @external
     @only_component_role("WITHDRAW_WON_PREMIUMS_ROLE")
@@ -1041,14 +1032,31 @@ class PremiumsAccount(ReserveMixin, AccessControlContract):
                 "Don't know where to source the rest of the money",
             )
 
+    def _max_deficit(self):
+        return -self.active_pure_premiums * self.deficit_ratio
+
     def _pay_from_premiums(self, to_pay):
         s = self.surplus - to_pay
-        max_deficit = -self.active_pure_premiums * self.deficit_ratio
+        max_deficit = self._max_deficit()
         if s >= max_deficit:
             self.surplus = s
             return Wad(0)
         self.surplus = max_deficit
         return -s + max_deficit
+
+    @property
+    @view
+    def funds_available(self):
+        return self.surplus - self._max_deficit()
+
+    @external
+    def repay_loans(self):
+        funds_available = self.funds_available
+        if funds_available and self.senior_etk:
+            funds_available = self._repay_loan(funds_available, self.senior_etk)
+        if self.junior_etk:
+            funds_available = self._repay_loan(funds_available, self.junior_etk)
+        return funds_available
 
     @external
     def policy_created(self, policy):
@@ -1063,32 +1071,24 @@ class PremiumsAccount(ReserveMixin, AccessControlContract):
     @external
     def policy_resolved_with_payout(self, customer, policy, payout):
         self.active_pure_premiums -= policy.pure_premium
+        borrow_from_scr = self._pay_from_premiums(payout - policy.pure_premium)
 
-        borrow_from_scr = Wad(0)
-        if policy.pure_premium >= payout:
-            pure_premium_won = policy.pure_premium - payout
-            if self.senior_etk:
-                pure_premium_won = self._repay_loan(pure_premium_won, self.senior_etk)
-            if self.junior_etk:
-                pure_premium_won = self._repay_loan(pure_premium_won, self.junior_etk)
-            self._store_pure_premium_won(pure_premium_won)
+        if borrow_from_scr:
             self._unlock_scr(policy)
+            self._borrow_from_etk(borrow_from_scr, customer, policy.jr_scr > Wad(0))
         else:
-            borrow_from_scr = self._pay_from_premiums(payout - policy.pure_premium)
             self._unlock_scr(policy)
-            if borrow_from_scr > 0:
-                self._borrow_from_etk(borrow_from_scr, customer, policy.jr_scr > Wad(0))
 
         self._transfer_to(customer, payout - borrow_from_scr)
         return borrow_from_scr
 
-    def _repay_loan(self, pure_premium_won, etk):
-        if pure_premium_won < self.NEGLIGIBLE_AMOUNT:
-            return pure_premium_won
+    def _repay_loan(self, funds_available, etk):
+        if funds_available < self.NEGLIGIBLE_AMOUNT:
+            return funds_available
         borrowed_from_etk = etk.get_loan(self)
         if not borrowed_from_etk:
-            return pure_premium_won
-        repay_amount = min(borrowed_from_etk, pure_premium_won)
+            return funds_available
+        repay_amount = min(borrowed_from_etk, funds_available)
 
         # If not enough liquidity, it deinvests from the asset manager
         if self.currency.balance_of(self) < repay_amount:
@@ -1098,24 +1098,14 @@ class PremiumsAccount(ReserveMixin, AccessControlContract):
             self.currency.approve(self, etk.contract_id, borrowed_from_etk)
 
         etk.repay_loan(self, repay_amount, self)
-        return pure_premium_won - repay_amount
+        self.surplus -= repay_amount
+        assert self.surplus >= self._max_deficit(), "Error, this shouldn't happen"
+        return funds_available - repay_amount
 
     @external
     def policy_expired(self, policy):
         self.active_pure_premiums -= policy.pure_premium
-        # Pay Ensuro and RM
-        pure_premium_won = policy.pure_premium
-        max_deficit = -self.active_pure_premiums * self.deficit_ratio
-        if self.surplus < max_deficit:
-            pure_premium_won -= -self.surplus + max_deficit
-            self.surplus = max_deficit
-
-        if self.senior_etk:
-            pure_premium_won = self._repay_loan(pure_premium_won, self.senior_etk)
-        if self.junior_etk:
-            pure_premium_won = self._repay_loan(pure_premium_won, self.junior_etk)
-
-        self._store_pure_premium_won(pure_premium_won)
+        self._store_pure_premium_won(policy.pure_premium)
         self._unlock_scr(policy)
 
     def _unlock_scr(self, policy):

--- a/prototype/wrappers.py
+++ b/prototype/wrappers.py
@@ -879,6 +879,7 @@ class PremiumsAccount(ReserveMixin, ETHWrapper):
     junior_etk = MethodAdapter((), "address", is_property=True)
     senior_etk = MethodAdapter((), "address", is_property=True)
     pure_premiums = MethodAdapter((), "amount", is_property=True)
+    funds_available = MethodAdapter((), "amount", is_property=True)
     surplus = MethodAdapter((), "amount", is_property=True)
     won_pure_premiums = MethodAdapter((), "amount", is_property=True)
     active_pure_premiums = MethodAdapter((), "amount", is_property=True)
@@ -911,17 +912,7 @@ class PremiumsAccount(ReserveMixin, ETHWrapper):
             return Wad(0)
 
     receive_grant = MethodAdapter((("sender", "msg.sender"), ("amount", "amount")))
-    repay_etoken_loan_ = MethodAdapter(
-        (("etoken", "contract"),), eth_method="repayETokenLoan"
-    )
-
-    def repay_etoken_loan(self, etoken_name):
-        etoken = self.etokens[etoken_name]
-        receipt = self.repay_etoken_loan_(etoken)
-        if "InternalLoanRepaid" in receipt.events:
-            return Wad(receipt.events["InternalLoanRepaid"]["value"])
-        else:
-            return Wad(0)
+    repay_loans = MethodAdapter(())
 
     def policy_created(self, policy):
         p = Policy.from_prototype_policy(policy, self.provider.address_book)

--- a/test/test-pause-unpause-permissions.js
+++ b/test/test-pause-unpause-permissions.js
@@ -338,6 +338,7 @@ describe("Test pause, unpause and upgrade contracts", function () {
     // Pause PremiumsAccount again
     await premiumsAccount.connect(guardian).pause();
 
+    await grantComponentRole(hre, accessManager, premiumsAccount, "REPAY_LOANS_ROLE", cust);
     // Can't resolve repayLoans
     await expect(premiumsAccount.connect(cust).repayLoans()).to.be.revertedWith("Pausable: paused");
 

--- a/test/test-pause-unpause-permissions.js
+++ b/test/test-pause-unpause-permissions.js
@@ -334,6 +334,18 @@ describe("Test pause, unpause and upgrade contracts", function () {
     await premiumsAccount.unpause();
     // Can resolve Policy
     await expect(rm.connect(cust).resolvePolicy(policy, _A(10))).not.to.be.reverted;
+
+    // Pause PremiumsAccount again
+    await premiumsAccount.connect(guardian).pause();
+
+    // Can't resolve repayLoans
+    await expect(premiumsAccount.connect(cust).repayLoans()).to.be.revertedWith("Pausable: paused");
+
+    // UnPause PolicyPool
+    await premiumsAccount.unpause();
+
+    // Can repayLoans
+    await expect(premiumsAccount.connect(cust).repayLoans()).not.to.be.reverted;
   });
 
   it("Pause and Unpause EToken trying to create and expire policies", async function () {

--- a/test/test-supports-interface.js
+++ b/test/test-supports-interface.js
@@ -115,6 +115,7 @@ describe("Supports interface implementation", function () {
     expect(await etk.supportsInterface(interfaceIds.IERC165)).to.be.true;
     expect(await etk.supportsInterface(interfaceIds.IERC20)).to.be.true;
     expect(await etk.supportsInterface(interfaceIds.IERC20Metadata)).to.be.true;
+    expect(await etk.supportsInterface(interfaceIds.IPolicyPoolComponent)).to.be.true;
     expect(await etk.supportsInterface(interfaceIds.IEToken)).to.be.true;
     expect(await etk.supportsInterface(interfaceIds.IERC721)).to.be.false;
   });
@@ -122,6 +123,7 @@ describe("Supports interface implementation", function () {
   it("Checks PremiumsAccount supported interfaces", async () => {
     const { interfaceIds, premiumsAccount } = await helpers.loadFixture(setupFixtureWithPoolAndPA);
     expect(await premiumsAccount.supportsInterface(interfaceIds.IERC165)).to.be.true;
+    expect(await premiumsAccount.supportsInterface(interfaceIds.IPolicyPoolComponent)).to.be.true;
     expect(await premiumsAccount.supportsInterface(interfaceIds.IPremiumsAccount)).to.be.true;
     expect(await premiumsAccount.supportsInterface(interfaceIds.IERC721)).to.be.false;
   });
@@ -140,6 +142,7 @@ describe("Supports interface implementation", function () {
     const TrustfulRiskModule = await hre.ethers.getContractFactory("TrustfulRiskModule");
     const rm = await TrustfulRiskModule.deploy(policyPool.address, premiumsAccount.address);
     expect(await rm.supportsInterface(interfaceIds.IERC165)).to.be.true;
+    expect(await rm.supportsInterface(interfaceIds.IPolicyPoolComponent)).to.be.true;
     expect(await rm.supportsInterface(interfaceIds.IRiskModule)).to.be.true;
     expect(await rm.supportsInterface(interfaceIds.IPremiumsAccount)).to.be.false;
   });

--- a/test/test-supports-interface.js
+++ b/test/test-supports-interface.js
@@ -11,11 +11,10 @@ describe("Supports interface implementation", function () {
      * Interface ids were calculated with this code, but we prefer to leave the values hard-coded, so this
      * test fails when we change some interface. This way we can be sure we don't change interfaces
      * by accident
-     */
-    /*
+     *
     const InterfaceIdCalculator = await ethers.getContractFactory("InterfaceIdCalculator");
     const iidCalculator = await InterfaceIdCalculator.deploy();
-    const interfaces = [
+    const iinterfaces = [
       "IERC165",
       "IERC20",
       "IERC20Metadata",
@@ -31,11 +30,11 @@ describe("Supports interface implementation", function () {
       "IAccessManager",
       "IAssetManager",
     ];
-    const interfaceIds = {};
-    for (const iName of interfaces) {
-      interfaceIds[iName] = await iidCalculator[iName.toUpperCase() + "_INTERFACEID"]();
+    const iinterfaceIds = {};
+    for (const iName of iinterfaces) {
+      iinterfaceIds[iName] = await iidCalculator[iName.toUpperCase() + "_INTERFACEID"]();
     }
-    // console.log(interfaceIds);
+    console.log(iinterfaceIds);
     */
     const interfaceIds = {
       IERC165: "0x01ffc9a7",
@@ -45,7 +44,7 @@ describe("Supports interface implementation", function () {
       IAccessControl: "0x7965db0b",
       IEToken: "0x90770621",
       IPolicyPool: "0x3234fad6",
-      IPolicyPoolComponent: "0x4cea22a4",
+      IPolicyPoolComponent: "0x4d15eb03",
       IRiskModule: "0xda40804f",
       IPremiumsAccount: "0xb76712ec",
       ILPWhitelist: "0xf8722d89",

--- a/tests/test_policypool.py
+++ b/tests/test_policypool.py
@@ -375,6 +375,8 @@ def test_walkthrough(tenv):
     rm = pool.risk_modules["Roulette"]
     premiums_account = rm.premiums_account
 
+    pool.access.grant_component_role(premiums_account, "REPAY_LOANS_ROLE", premiums_account.owner)
+
     with pytest.raises(RevertError, match="transfer amount exceeds allowance|insufficient allowance"):
         pool.deposit("eUSD1YEAR", "LP1", _W(1000))
 
@@ -2423,6 +2425,7 @@ def test_repay_loan(tenv):
     rm = pool.risk_modules["Roulette"]
     pool.access.grant_component_role(rm, "PRICER_ROLE", rm.owner)
     pool.access.grant_component_role(rm, "RESOLVER_ROLE", rm.owner)
+    pool.access.grant_role("REPAY_LOANS_ROLE", rm.owner)
     pa = rm.premiums_account
 
     USD = pool.currency
@@ -2551,6 +2554,7 @@ def test_loss_propagation_limits(tenv):
     pool.access.grant_component_role(rm, "PRICER_ROLE", rm.owner)
     pool.access.grant_component_role(rm, "RESOLVER_ROLE", rm.owner)
     pa = rm.premiums_account
+    pool.access.grant_component_role(pa, "REPAY_LOANS_ROLE", pa.owner)
 
     USD = pool.currency
     etkSr = pool.etokens["eUSDSr"]

--- a/tests/test_premiumsaccount.py
+++ b/tests/test_premiumsaccount.py
@@ -227,12 +227,18 @@ def test_withdraw_won_premiums_with_borrowed_active_pp(tenv):
     with pa.thru_policy_pool():
         pa.policy_expired(policy)
 
-    # Check repayment made
+    assert pa.funds_available == policy.pure_premium
+    senior_etk.get_loan(pa).assert_equal(senior_loan)
+    pa.repay_loans()
     senior_etk.get_loan(pa).assert_equal(senior_loan - policy.pure_premium)
+    assert pa.funds_available == _W(0)
+
     tenv.currency.allowance(pa, senior_etk).assert_equal(senior_loan - policy.pure_premium)
     senior_loan = senior_etk.get_loan(pa)
 
     pa.receive_grant(tenv.currency.owner, _W(100))
+    assert pa.funds_available == _W(100)
+    pa.repay_loans()
     pa.won_pure_premiums.assert_equal(_W(100) - senior_loan)
 
     senior_etk.get_loan(pa).assert_equal(_W(0))
@@ -664,6 +670,71 @@ def test_pay_from_premium(tenv):
     # with pytest.raises(RevertError, match="ERC20: transfer amount exceeds balance"):
     with pa.thru_policy_pool():
         pa.policy_resolved_with_payout(tenv.currency.owner, policy, _W(20))
+
+
+def test_payout_equal_pure_premium(tenv):
+    senior_etk = tenv.etk(name="eUSD1YEAR", symbol="ETK1")
+    pa = tenv.pa_class(senior_etk=senior_etk)
+    start = tenv.time_control.now
+    expiration = tenv.time_control.now + WEEK
+
+    tenv.currency.transfer(tenv.currency.owner, senior_etk, _W(1000))
+    with senior_etk.thru_policy_pool():
+        assert senior_etk.deposit("LP1", _W(1000)) == _W(1000)
+        senior_etk.add_borrower(pa)
+
+    rm = RiskModule(
+        premiums_account="dummy",
+        name="Roulette",
+        policy_pool="dummy",
+        coll_ratio=_W("1"),
+    )
+
+    policy = ensuro.Policy(
+        id=1,
+        risk_module=rm,
+        payout=_W(20),
+        premium=_W(12),
+        loss_prob=_W(1 / 2),
+        start=start,
+        expiration=expiration,
+    )
+
+    with pa.thru_policy_pool():
+        pa.policy_created(policy)
+    pa.active_pure_premiums.assert_equal(_W(10))
+
+    policy_2 = ensuro.Policy(
+        id=2,
+        risk_module=rm,
+        payout=_W(20),
+        premium=_W(12),
+        loss_prob=_W(1 / 2),
+        start=start,
+        expiration=expiration,
+    )
+
+    with pa.thru_policy_pool():
+        pa.policy_created(policy_2)
+
+    pa.active_pure_premiums.assert_equal(_W(20))
+    pa.borrowed_active_pp.assert_equal(_W(0))
+    pa.won_pure_premiums.assert_equal(_W(0))
+
+    # Replicate premium transfers
+    tenv.currency.transfer(tenv.currency.owner, pa, policy.pure_premium + policy_2.pure_premium)
+    tenv.currency.transfer(tenv.currency.owner, senior_etk, policy.sr_coc + policy_2.sr_coc)
+
+    # Resolve 1st policy
+    with pa.thru_policy_pool():
+        pa.policy_resolved_with_payout(tenv.currency.owner, policy_2, _W(20))
+
+    pa.active_pure_premiums.assert_equal(_W(10))
+    pa.borrowed_active_pp.assert_equal(_W(10))
+    pa.won_pure_premiums.assert_equal(_W(0))
+
+    with pa.thru_policy_pool():
+        pa.policy_resolved_with_payout(tenv.currency.owner, policy, _W(10))
 
 
 def test_set_loan_limits(tenv):

--- a/tests/test_premiumsaccount.py
+++ b/tests/test_premiumsaccount.py
@@ -108,7 +108,6 @@ def test_receive_grant(tenv):
     tenv.currency.approve(tenv.currency.owner, pa, _W(1000))
     assert tenv.currency.allowance(tenv.currency.owner, pa) == _W(1000)
 
-    pa.receive_grant(tenv.currency.owner, _W(0))
     pa.receive_grant(tenv.currency.owner, _W(100))
 
     pa.active_pure_premiums.assert_equal(_W(0))


### PR DESCRIPTION
Previously it was trying to do the repayment of the loans automatically in each point of the code where a pure premium was won. This wasn't effective because it's a waste of resources when the PA is not in debt (most of the time). Also, when the PA is in debt this produces a lot of micro-payments increasing the gas usage and also making the PA more prone to take debt in the near term.

Now the debt repayment has been moved to a new public method. This can be called at any time given enough funds available.

Funds available are calculated as (surplus - _maxDeficit), so the PA will take as much deficit as needed to repay the debt.

Also in the previous version the debt was only repaid with won pure premiums. Given this change, it can be paid with pure premiums comming from new business. A good risk management must be made to avoid postponing the bad performance of a growing portfolio to the future.