### PR TITLE
Fix DeinvestAll Bug

### DIFF
--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -6,5 +6,6 @@ compiler:
       runs: 200
     remappings:
       - "@openzeppelin=node_modules/@openzeppelin"
+      - "hardhat=node_modules/hardhat"
 networks:
   default: hardhat

--- a/contracts/ERC4626AssetManager.sol
+++ b/contracts/ERC4626AssetManager.sol
@@ -43,7 +43,7 @@ contract ERC4626AssetManager is LiquidityThresholdAssetManager {
     DiamondStorage storage ds = diamondStorage();
     uint256 assets = _vault.redeem(_vault.balanceOf(address(this)), address(this), address(this));
     earnings = int256(assets) - int256(uint256(ds.lastInvestmentValue));
-    ds.lastInvestmentValue = assets.toUint128();
+    ds.lastInvestmentValue = 0;
     emit MoneyDeinvested(assets);
     emit EarningsRecorded(earnings);
     return earnings;

--- a/contracts/LiquidityThresholdAssetManager.sol
+++ b/contracts/LiquidityThresholdAssetManager.sol
@@ -71,6 +71,13 @@ abstract contract LiquidityThresholdAssetManager is IAssetManager {
       IPolicyPoolComponent(address(this)).policyPool().currency() == _asset,
       "Asset mismatch"
     );
+    DiamondStorage storage ds = diamondStorage();
+    // When connecting I make sure the storage is clean, to avoid reusing data from previous AM that left
+    // the data in a wrong state.
+    ds.liquidityMin = 0;
+    ds.liquidityMiddle = 0;
+    ds.liquidityMax = 0;
+    ds.lastInvestmentValue = 0;
   }
 
   function recordEarnings() external virtual override returns (int256) {

--- a/contracts/Reserve.sol
+++ b/contracts/Reserve.sol
@@ -152,6 +152,11 @@ abstract contract Reserve is PolicyPoolComponent {
         } else {
           _assetEarnings(abi.decode(result, (int256)));
         }
+        /**
+         * WARNING: if you are doing a forced replacement of the AM and you want the new AM
+         * to inherit the storage (just fixing the code), make sure the code of the new AM doesn't clean
+         * the storage in the connect() method (as it is the recommended practice in normal changes of AM).
+         */
       } else {
         bytes memory result = am.functionDelegateCall(
           abi.encodeWithSelector(IAssetManager.deinvestAll.selector)

--- a/contracts/TimeScaled.sol
+++ b/contracts/TimeScaled.sol
@@ -116,6 +116,10 @@ library TimeScaled {
     int256 amount,
     uint256 interestRate
   ) internal {
+    if (scaledAmount.amount == 0) {
+      add(scaledAmount, uint256(amount), interestRate);
+      return;
+    }
     updateScale(scaledAmount, interestRate);
     uint256 newScaledAmount = uint256(int256(getScaledAmount(scaledAmount, interestRate)) + amount);
     scaledAmount.scale = newScaledAmount

--- a/contracts/interfaces/IAssetManager.sol
+++ b/contracts/interfaces/IAssetManager.sol
@@ -38,6 +38,11 @@ interface IAssetManager is IERC165 {
 
   /**
    * @dev Function called when an asset manager is plugged into a reserve. Useful for initialization tasks
+   *
+   * Since the asset manager for a reserve can be changed and they use the stoage of the reserve contract, you
+   * can't assume the storage starts clean (all zeros). This is because a previous AM, using the same hash for the
+   * diamondStorage might have left some data. So, in the connect method you should initialize the state setting to
+   * zero what's expected to be zero.
    */
   function connect() external;
 

--- a/prototype/ensuro.py
+++ b/prototype/ensuro.py
@@ -1408,7 +1408,8 @@ class FixedRateVault(ERC20Token):
             self.asset.mint(self.contract_id, assets - balance)
         require(caller == owner, "Only owner can withdraw for now")  # TODO: allowance
         self.burn(owner, shares)
-        self.asset.transfer(self, receiver, assets)
+        if assets:
+            self.asset.transfer(self, receiver, assets)
 
     @external
     def discrete_earning(self, assets):

--- a/prototype/wrappers.py
+++ b/prototype/wrappers.py
@@ -83,7 +83,7 @@ class ReserveMixin:
     forward_to_asset_manager_ = MethodAdapter((("functionCall", "bytes"),))
 
     set_asset_manager = MethodAdapter((("assetManager", "address"), ("force", "bool")))
-    asset_manager = MethodAdapter((), is_property=True)
+    asset_manager = MethodAdapter((), "address", is_property=True)
     checkpoint = MethodAdapter(())
     record_earnings = MethodAdapter(())
     rebalance = MethodAdapter(())

--- a/tests/test_etoken.py
+++ b/tests/test_etoken.py
@@ -687,9 +687,16 @@ def test_etk_asset_manager_without_movements(tenv):
     with etk.as_("ADMIN"):
         etk.set_asset_manager(asset_manager, False)
 
+    if tenv.kind == "prototype":
+        assert etk.asset_manager == asset_manager.contract_id
+    else:
+        assert etk.asset_manager == asset_manager.contract.address
+
     # Unset asset manager
     with etk.as_("ADMIN"):
         etk.set_asset_manager(None, False)
+
+    assert etk.asset_manager is None or etk.asset_manager == "0x0000000000000000000000000000000000000000"
 
 
 @skip_if_coverage_activated

--- a/tests/test_etoken.py
+++ b/tests/test_etoken.py
@@ -606,6 +606,93 @@ def test_etk_asset_manager(tenv):
 
 
 @skip_if_coverage_activated
+def test_etk_change_asset_manager(tenv):
+    etk = tenv.etoken_class(name="eUSD1WEEK")
+
+    # Initial setup
+    tenv.currency.transfer(tenv.currency.owner, etk, _W(3000))
+    with etk.thru_policy_pool():
+        etk.deposit("LP1", _W(1000))
+        etk.deposit("LP2", _W(2000))
+    assert etk.total_supply() == _W(3000)
+    assert etk.get_current_scale(True) == _R(1)
+    assert etk.get_current_scale(False) == _R(1)
+    tenv.currency.balance_of(etk).assert_equal(_W(3000))
+
+    # Create vault
+    vault = tenv.module.FixedRateVault(asset=tenv.currency)
+    asset_manager = tenv.module.ERC4626AssetManager(
+        vault=vault, reserve=etk,
+    )
+
+    tenv.pool_access.grant_role("LEVEL1_ROLE", "ADMIN")
+
+    # Set asset manager
+    with etk.as_("ADMIN"):
+        etk.set_asset_manager(asset_manager, False)
+
+    tenv.pool_access.grant_component_role(etk, "LEVEL2_ROLE", "ADMIN")
+
+    with etk.as_("ADMIN"):
+        etk.forward_to_asset_manager("set_liquidity_thresholds", _W(100), _W(160), _W(200))
+
+    # Rebalance
+    vault.total_assets().assert_equal(_W(0))
+    # After checkpoint the cash should be rebalanced
+    etk.rebalance()
+    vault.total_assets().assert_equal(_W(2840))
+    tenv.currency.balance_of(etk).assert_equal(_W(160))
+
+    etk.record_earnings()
+    etk.total_supply().assert_equal(_W(3000))  # Nothing earned yet
+
+    vault_2 = tenv.module.FixedRateVault(asset=tenv.currency)
+    asset_manager_2 = tenv.module.ERC4626AssetManager(
+        vault=vault_2, reserve=etk,
+    )
+
+    with etk.as_("ADMIN"):
+        etk.set_asset_manager(asset_manager_2, False)
+
+    if tenv.kind == "prototype":
+        assert etk.asset_manager == asset_manager_2.contract_id
+    else:
+        assert etk.asset_manager == asset_manager_2.contract.address
+
+    with etk.as_("ADMIN"):
+        etk.forward_to_asset_manager("set_liquidity_thresholds", _W(100), _W(160), _W(200))
+
+    vault.total_assets().assert_equal(_W(0))  # All deinvested
+    tenv.currency.balance_of(etk).assert_equal(_W(3000))
+    etk.rebalance()
+
+    etk.record_earnings()
+    tenv.currency.balance_of(etk).assert_equal(_W(160))
+    etk.total_supply().assert_equal(_W(3000))  # Nothing earned yet
+
+
+@skip_if_coverage_activated
+def test_etk_asset_manager_without_movements(tenv):
+    etk = tenv.etoken_class(name="eUSD1WEEK")
+
+    # Create vault
+    vault = tenv.module.FixedRateVault(asset=tenv.currency)
+    asset_manager = tenv.module.ERC4626AssetManager(
+        vault=vault, reserve=etk,
+    )
+
+    tenv.pool_access.grant_role("LEVEL1_ROLE", "ADMIN")
+
+    # Set asset manager
+    with etk.as_("ADMIN"):
+        etk.set_asset_manager(asset_manager, False)
+
+    # Unset asset manager
+    with etk.as_("ADMIN"):
+        etk.set_asset_manager(None, False)
+
+
+@skip_if_coverage_activated
 def test_etk_asset_manager_liquidity_under_minimum(tenv):
     etk = tenv.etoken_class(name="eUSD1WEEK")
 


### PR DESCRIPTION
When unplugging an Asset Manager it was leaving the lastInvestmentValue with a wrong value. Then when a new Asset Manager is plugged, it reuses the same storage and assumes the lastInvestmentValue is different than the real value.