### PR TITLE
Upstreaming of several utils and test-utils from other repos. Other improvements un utilities.

### DIFF
--- a/js/constants.js
+++ b/js/constants.js
@@ -1,7 +1,13 @@
-const WEEK = 3600 * 24 * 7;
-const DAY = 3600 * 24;
+const HOUR = 3600;
+const WEEK = HOUR * 24 * 7;
+const DAY = HOUR * 24;
+
+// From https://eips.ethereum.org/EIPS/eip-1967
+const IMPLEMENTATION_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
 
 module.exports = {
   WEEK,
   DAY,
+  HOUR,
+  IMPLEMENTATION_SLOT,
 };

--- a/js/enums.js
+++ b/js/enums.js
@@ -4,7 +4,29 @@ const WhitelistStatus = {
   blacklisted: 2,
 };
 
+const ComponentKind = {
+  eToken: 1,
+  riskModule: 2,
+  premiumsAccount: 3,
+};
+
+const ComponentStatus = {
+  inactive: 0,
+  active: 1,
+  deprecated: 2,
+  suspended: 3,
+};
+
+const ETokenParameter = {
+  // From IEToken.Parameter
+  liquidityRequirement: 0,
+  minUtilizationRate: 1,
+  maxUtilizationRate: 2,
+  internalLoanInterestRate: 3,
+};
+
 const RiskModuleParameter = {
+  // From IRiskModule.Parameter
   moc: 0,
   jrCollRatio: 1,
   collRatio: 2,
@@ -17,14 +39,10 @@ const RiskModuleParameter = {
   maxDuration: 9,
 };
 
-const ComponentKind = {
-  eToken: 1,
-  riskModule: 2,
-  premiumsAccount: 3,
-};
-
 module.exports = {
-  WhitelistStatus,
-  RiskModuleParameter,
   ComponentKind,
+  ComponentStatus,
+  ETokenParameter,
+  RiskModuleParameter,
+  WhitelistStatus,
 };

--- a/js/test-utils.js
+++ b/js/test-utils.js
@@ -226,6 +226,24 @@ async function makePolicy(pool, rm, cust, payout, premium, lossProb, expiration,
   return newPolicyEvt;
 }
 
+const skipForkTests = process.env.SKIP_FORK_TESTS === "true";
+const forkIt = skipForkTests ? it.skip : it;
+
+async function fork(blockNumber) {
+  if (process.env.ALCHEMY_URL === undefined) throw new Error("Define envvar ALCHEMY_URL for this test");
+  return hre.network.provider.request({
+    method: "hardhat_reset",
+    params: [
+      {
+        forking: {
+          jsonRpcUrl: process.env.ALCHEMY_URL,
+          blockNumber: blockNumber,
+        },
+      },
+    ],
+  });
+}
+
 if (process.env.ENABLE_HH_WARNINGS !== "yes") hre.upgrades.silenceWarnings();
 
 module.exports = {
@@ -235,6 +253,9 @@ module.exports = {
   createRiskModule,
   deployPool,
   deployPremiumsAccount,
+  fork,
+  forkIt,
   initCurrency,
   makePolicy,
+  skipForkTests,
 };

--- a/js/utils.js
+++ b/js/utils.js
@@ -246,6 +246,15 @@ async function readImplementationAddress(contractAddress) {
   return ethers.utils.getAddress(ethers.utils.hexDataSlice(implStorage, 12));
 }
 
+/**
+ * Converts a string value to uint256(keccak(value))
+ * @param {string} value
+ * @returns {ethers.BigNumber}
+ */
+function uintKeccak(value) {
+  return ethers.BigNumber.from(ethers.utils.keccak256(ethers.utils.toUtf8Bytes(value)));
+}
+
 module.exports = {
   _BN,
   _E,
@@ -267,5 +276,6 @@ module.exports = {
   makeSignedQuote,
   RAY,
   readImplementationAddress,
+  uintKeccak,
   WAD,
 };

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,6 +1,7 @@
 const { findAll } = require("solidity-ast/utils");
 const ethers = require("ethers");
 const helpers = require("@nomicfoundation/hardhat-network-helpers");
+const { DAY, IMPLEMENTATION_SLOT } = require("./constants");
 
 const _E = ethers.utils.parseEther;
 const _BN = ethers.BigNumber.from;
@@ -234,10 +235,15 @@ async function defaultPolicyParams(
     payout: payout || _A(1000),
     premium: premium || ethers.constants.MaxUint256,
     lossProb: lossProb || _W(0.1),
-    expiration: expiration || now + 3600 * 24 * 30,
+    expiration: expiration || now + DAY * 30,
     policyData: policyData || ethers.utils.hexlify(ethers.utils.randomBytes(32)),
-    validUntil: validUntil || now + 3600 * 24 * 30,
+    validUntil: validUntil || now + DAY * 30,
   };
+}
+
+async function readImplementationAddress(contractAddress) {
+  const implStorage = await ethers.provider.getStorageAt(contractAddress, IMPLEMENTATION_SLOT);
+  return ethers.utils.getAddress(ethers.utils.hexDataSlice(implStorage, 12));
 }
 
 module.exports = {
@@ -260,5 +266,6 @@ module.exports = {
   makeQuoteMessage,
   makeSignedQuote,
   RAY,
+  readImplementationAddress,
   WAD,
 };

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -264,8 +264,11 @@ async function deployRiskModule(
   },
   hre
 ) {
-  extraArgs = extraArgs || [];
-  extraConstructorArgs = extraConstructorArgs || [];
+  extraArgs = typeof extraArgs === "string" ? JSON.parse(extraArgs) : extraArgs || [];
+
+  extraConstructorArgs =
+    typeof extraConstructorArgs === "string" ? JSON.parse(extraConstructorArgs) : extraConstructorArgs || [];
+
   const { contract } = await deployProxyContract(
     {
       contractClass: rmClass,
@@ -583,6 +586,8 @@ function add_task() {
     .addOptionalParam("exposureLimit", "Exposure (sum of payouts) limit for the RM", 1e6, types.float)
     .addOptionalParam("maxDuration", "Maximum policy duration in hours", 24 * 365, types.int)
     .addOptionalParam("moc", "Margin of Conservativism", 1.0, types.float)
+    .addOptionalParam("extraConstructorArgs", "Additional constructor args", undefined, types.str)
+    .addOptionalParam("extraArgs", "Additional initializer args", undefined, types.str)
     .addParam("wallet", "RM address", types.address)
     .setAction(deployRiskModule);
 

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -87,7 +87,12 @@ async function verifyContract(hre, contract, isProxy, constructorArguments) {
     });
   } catch (error) {
     console.log("Error verifying contract implementation: ", error);
-    console.log("Constructor args were: ", JSON.stringify(constructorArguments));
+    console.log("You can retry with:");
+    console.log(
+      `    npx hardhat verify --network '${hre.network.name}' '${address}' ${constructorArguments
+        .map((a) => `'${a.toString()}'`)
+        .join(" ")}`
+    );
   }
   try {
     if (isProxy) {

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -1,7 +1,6 @@
 const upgrades_core = require("@openzeppelin/upgrades-core");
 const helpers = require("@nomicfoundation/hardhat-network-helpers");
 const fs = require("fs");
-const { request } = require("undici");
 const ethers = require("ethers");
 const { task, types } = require("hardhat/config");
 const { WhitelistStatus } = require("../js/enums");
@@ -78,39 +77,28 @@ async function logContractCreated(hre, contractName, address) {
 async function verifyContract(hre, contract, isProxy, constructorArguments) {
   if (isProxy === undefined) isProxy = false;
   if (constructorArguments === undefined) constructorArguments = [];
-  let address = contract.address;
-  if (isProxy) address = await upgrades_core.getImplementationAddress(hre.network.provider, address);
+  const address = isProxy
+    ? await upgrades_core.getImplementationAddress(hre.network.provider, contract.address)
+    : contract.address;
   try {
     await hre.run("verify:verify", {
       address: address,
       constructorArguments: constructorArguments,
     });
+  } catch (error) {
+    console.log("Error verifying contract implementation: ", error);
+    console.log("Constructor args were: ", JSON.stringify(constructorArguments));
+  }
+  try {
     if (isProxy) {
-      // the following should work but it fails with the current @openzeppelin/hardhat-upgrades version (1.20.0)
-      // await hre.run("verify:verify", {
-      //   address: contract.address,
-      // });
-
-      // so we use the following workaround
-      const endpoints = await hre.run("verify:get-etherscan-endpoint");
-      const params = new URLSearchParams({
-        module: "contract",
-        action: "verifyproxycontract",
-        apiKey: hre.config.etherscan.apiKey,
+      await hre.run("verify:verify", {
         address: contract.address,
       });
-      const response = await request(endpoints.urls.apiURL, {
-        method: "POST",
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-        body: params.toString(),
-      });
-      if (response.statusCode != 200)
-        throw new Error(`Etherscan replied with ${response.statusCode}: ${await response.body.text()}`);
-      const body = await response.body.json();
-      if (body.status != 1) throw new Error(`Etherscan replied with ${body}`);
     }
   } catch (error) {
-    console.log("Error verifying contract", error);
+    console.log("Error verifying contract proxy: ", error);
+    const endpoints = await hre.run("verify:get-etherscan-endpoint");
+    console.log(`You should do it manually at ${endpoints.urls.browserURL}/proxyContractChecker?a=${contract.address}`);
   }
 }
 


### PR DESCRIPTION
**IMPORTANT**: has to be merged after https://github.com/ensuro/ensuro/pull/160

- extraConstructorArgs in deploy:riskModule
- readImplementationAddress from deploy-scripts fixtures
- ComponentStatus enum from deploy-scripts `test/test-v26-policypool.js`
- fork/forkIt/skipForkTests from price-risk-module `test/utils.js`
- fork currency (impersonate whale+transfer or mint?)
- HOUR constant
- getBucketId from from deploy-scripts `changeset.js` -> renamed as uintKeccak
- Remove workaround for hardhat verify:verify on proxy contracts