### PR TITLE
Policy Replacement

### DIFF
--- a/contracts/Policy.sol
+++ b/contracts/Policy.sol
@@ -40,8 +40,9 @@ library Policy {
     uint256 premium,
     uint256 payout,
     uint256 lossProb,
-    uint40 expiration
-  ) internal view returns (PolicyData memory newPolicy) {
+    uint40 expiration,
+    uint40 start
+  ) internal pure returns (PolicyData memory newPolicy) {
     require(premium <= payout, "Premium cannot be more than payout");
     PolicyData memory policy;
 
@@ -49,7 +50,7 @@ library Policy {
     policy.premium = premium;
     policy.payout = payout;
     policy.lossProb = lossProb;
-    policy.start = uint40(block.timestamp);
+    policy.start = start;
     policy.expiration = expiration;
     policy.purePremium = payout.wadMul(lossProb.wadMul(rmParams.moc));
     // Calculate Junior and Senior SCR

--- a/contracts/PolicyPool.sol
+++ b/contracts/PolicyPool.sol
@@ -507,7 +507,8 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
      * operate on low gas-cost blockchains, we keep it as it is.
      */
 
-    emit PolicyReplaced(rm, oldPolicy.id, newPolicy_);
+    emit NewPolicy(rm, newPolicy_);
+    emit PolicyReplaced(rm, oldPolicy.id, newPolicy_.id);
     return newPolicy_.id;
   }
 

--- a/contracts/PolicyPool.sol
+++ b/contracts/PolicyPool.sol
@@ -381,21 +381,14 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
     return _components[component].status;
   }
 
-  function _componentStatus(address component, ComponentKind kind)
-    internal
-    view
-    returns (ComponentStatus)
-  {
+  function _componentStatus(address component, ComponentKind kind) internal view returns (ComponentStatus) {
     Component storage comp = _components[IPolicyPoolComponent(component)];
     require(comp.kind == kind, "Component is not of the right kind");
     return comp.status;
   }
 
   function _requireCompActive(address component, ComponentKind kind) internal view {
-    require(
-      _componentStatus(component, kind) == ComponentStatus.active,
-      "Component not found or not active"
-    );
+    require(_componentStatus(component, kind) == ComponentStatus.active, "Component not found or not active");
   }
 
   function _requireCompActiveOrDeprecated(address component, ComponentKind kind) internal view {

--- a/contracts/PolicyPool.sol
+++ b/contracts/PolicyPool.sol
@@ -425,7 +425,7 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
     _requireCompActive(address(pa), ComponentKind.premiumsAccount);
 
     // Effects
-    policy.id = _makePolicyId(rm, internalId);
+    policy.id = makePolicyId(rm, internalId);
     require(_policies[policy.id] == bytes32(0), "Policy already exists");
     _policies[policy.id] = policy.hash();
     _safeMint(policyHolder, policy.id, "");
@@ -480,7 +480,7 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
     );
 
     // Effects
-    newPolicy_.id = _makePolicyId(rm, internalId);
+    newPolicy_.id = makePolicyId(rm, internalId);
     require(_policies[newPolicy_.id] == bytes32(0), "Policy already exists");
     _policies[newPolicy_.id] = newPolicy_.hash();
     address policyHolder = ownerOf(oldPolicy.id);
@@ -516,7 +516,7 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
     require(policy.id != 0 && policy.hash() == _policies[policy.id], "Policy not found");
   }
 
-  function _makePolicyId(IRiskModule rm, uint96 internalId) internal pure returns (uint256) {
+  function makePolicyId(IRiskModule rm, uint96 internalId) public pure returns (uint256) {
     return (uint256(uint160(address(rm))) << 96) + internalId;
   }
 

--- a/contracts/PolicyPool.sol
+++ b/contracts/PolicyPool.sol
@@ -126,25 +126,6 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
   string internal _nftBaseURI;
 
   /**
-   * @dev Event emitted every time a new policy is added to the pool. Contains all the data about the policy that is
-   * later required for doing operations with the policy like resolution or expiration.
-   *
-   * @param riskModule The risk module that created the policy
-   * @param policy The {Policy-PolicyData} struct with all the immutable fields of the policy.
-   */
-  event NewPolicy(IRiskModule indexed riskModule, Policy.PolicyData policy);
-
-  /**
-   * @dev Event emitted every time a policy is removed from the pool. If the policy expired, the `payout` is 0,
-   * otherwise is the amount transferred to the policyholder.
-   *
-   * @param riskModule The risk module where that created the policy initially.
-   * @param policyId The unique id of the policy
-   * @param payout The payout that has been paid to the policy holder. 0 when the policy expired.
-   */
-  event PolicyResolved(IRiskModule indexed riskModule, uint256 indexed policyId, uint256 payout);
-
-  /**
    * @dev Event emitted when the treasury changes
    *
    * @param action The type of governance action (setTreasury or setBaseURI for now)
@@ -400,39 +381,41 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
     return _components[component].status;
   }
 
-  function _etkStatus(IEToken eToken) internal view returns (ComponentStatus) {
-    Component storage comp = _components[IPolicyPoolComponent(address(eToken))];
-    require(comp.kind == ComponentKind.eToken, "Component is not an eToken");
+  function _componentStatus(address component, ComponentKind kind)
+    internal
+    view
+    returns (ComponentStatus)
+  {
+    Component storage comp = _components[IPolicyPoolComponent(component)];
+    require(comp.kind == kind, "Component is not of the right kind");
     return comp.status;
   }
 
-  function _rmStatus(IRiskModule riskModule) internal view returns (ComponentStatus) {
-    Component storage comp = _components[IPolicyPoolComponent(address(riskModule))];
-    require(comp.kind == ComponentKind.riskModule, "Component is not a RiskModule");
-    return comp.status;
+  function _requireCompActive(address component, ComponentKind kind) internal view {
+    require(
+      _componentStatus(component, kind) == ComponentStatus.active,
+      "Component not found or not active"
+    );
   }
 
-  function _paStatus(IPremiumsAccount premiumsAccount) internal view returns (ComponentStatus) {
-    Component storage comp = _components[IPolicyPoolComponent(address(premiumsAccount))];
-    require(comp.kind == ComponentKind.premiumsAccount, "Component is not a PremiumsAccount");
-    return comp.status;
+  function _requireCompActiveOrDeprecated(address component, ComponentKind kind) internal view {
+    ComponentStatus status = _componentStatus(component, kind);
+    require(
+      status == ComponentStatus.active || status == ComponentStatus.deprecated,
+      "Component must be active or deprecated"
+    );
   }
 
   function deposit(IEToken eToken, uint256 amount) external override whenNotPaused {
-    require(_etkStatus(eToken) == ComponentStatus.active, "eToken is not active");
+    _requireCompActive(address(eToken), ComponentKind.eToken);
     uint256 balanceBefore = _currency.balanceOf(address(eToken));
     _currency.safeTransferFrom(_msgSender(), address(eToken), amount);
     eToken.deposit(_msgSender(), _currency.balanceOf(address(eToken)) - balanceBefore);
   }
 
   function withdraw(IEToken eToken, uint256 amount) external override whenNotPaused returns (uint256) {
-    ComponentStatus etkStatus = _etkStatus(eToken);
-    require(
-      etkStatus == ComponentStatus.active || etkStatus == ComponentStatus.deprecated,
-      "eToken not found or withdraws not allowed"
-    );
-    address provider = _msgSender();
-    return eToken.withdraw(provider, amount);
+    _requireCompActiveOrDeprecated(address(eToken), ComponentKind.eToken);
+    return eToken.withdraw(_msgSender(), amount);
   }
 
   function newPolicy(
@@ -444,14 +427,15 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
     // Checks
     IRiskModule rm = policy.riskModule;
     require(address(rm) == _msgSender(), "Only the RM can create new policies");
-    require(_rmStatus(rm) == ComponentStatus.active, "RM module not found or not active");
+    _requireCompActive(address(rm), ComponentKind.riskModule);
     IPremiumsAccount pa = rm.premiumsAccount();
-    require(_paStatus(pa) == ComponentStatus.active, "PremiumsAccount not found or not active");
+    _requireCompActive(address(pa), ComponentKind.premiumsAccount);
 
     // Effects
-    policy.id = (uint256(uint160(address(rm))) << 96) + internalId;
+    policy.id = _makePolicyId(rm, internalId);
     require(_policies[policy.id] == bytes32(0), "Policy already exists");
     _policies[policy.id] = policy.hash();
+    _safeMint(policyHolder, policy.id, "");
 
     // Interactions
     pa.policyCreated(policy);
@@ -468,14 +452,78 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
      * transfers. This might be considered in the future, but to avoid increasing the complexity and since so far we
      * operate on low gas-cost blockchains, we keep it as it is.
      */
-    _safeMint(policyHolder, policy.id, "");
 
     emit NewPolicy(rm, policy);
     return policy.id;
   }
 
+  function replacePolicy(
+    Policy.PolicyData memory oldPolicy,
+    Policy.PolicyData memory newPolicy_,
+    address payer,
+    uint96 internalId
+  ) external override whenNotPaused returns (uint256) {
+    // Checks
+    _validatePolicy(oldPolicy);
+    IRiskModule rm = oldPolicy.riskModule;
+    require(address(rm) == _msgSender(), "Only the RM can create new policies");
+    _requireCompActive(address(rm), ComponentKind.riskModule);
+    IPremiumsAccount pa = rm.premiumsAccount();
+    _requireCompActive(address(pa), ComponentKind.premiumsAccount);
+    require(oldPolicy.expiration > uint40(block.timestamp), "Old policy is expired");
+    require(oldPolicy.start == newPolicy_.start, "Both policies must have the same starting date");
+    require(
+      oldPolicy.payout <= newPolicy_.payout &&
+        oldPolicy.purePremium <= newPolicy_.purePremium &&
+        oldPolicy.ensuroCommission <= newPolicy_.ensuroCommission &&
+        oldPolicy.jrCoc <= newPolicy_.jrCoc &&
+        oldPolicy.srCoc <= newPolicy_.srCoc &&
+        oldPolicy.jrScr <= newPolicy_.jrScr &&
+        oldPolicy.srScr <= newPolicy_.srScr &&
+        oldPolicy.partnerCommission <= newPolicy_.partnerCommission &&
+        oldPolicy.expiration <= newPolicy_.expiration &&
+        rm == newPolicy_.riskModule,
+      "New policy must be greater or equal than old policy"
+    );
+
+    // Effects
+    newPolicy_.id = _makePolicyId(rm, internalId);
+    require(_policies[newPolicy_.id] == bytes32(0), "Policy already exists");
+    _policies[newPolicy_.id] = newPolicy_.hash();
+    address policyHolder = ownerOf(oldPolicy.id);
+    _safeMint(policyHolder, newPolicy_.id, "");
+    delete _policies[oldPolicy.id];
+
+    // Interactions
+    pa.policyReplaced(oldPolicy, newPolicy_);
+
+    // Distribute the premium
+    uint256 aux = newPolicy_.purePremium - oldPolicy.purePremium;
+    if (aux > 0) _currency.safeTransferFrom(payer, address(pa), aux);
+    aux = newPolicy_.srCoc - oldPolicy.srCoc;
+    if (aux > 0) _currency.safeTransferFrom(payer, address(pa.seniorEtk()), aux);
+    aux = newPolicy_.jrCoc - oldPolicy.jrCoc;
+    if (aux > 0) _currency.safeTransferFrom(payer, address(pa.juniorEtk()), aux);
+    aux = newPolicy_.ensuroCommission - oldPolicy.ensuroCommission;
+    if (aux > 0) _currency.safeTransferFrom(payer, _treasury, aux);
+    aux = newPolicy_.partnerCommission - oldPolicy.partnerCommission;
+    if (aux > 0 && payer != rm.wallet()) _currency.safeTransferFrom(payer, rm.wallet(), aux);
+    /**
+     * This code does up to 5 ERC20 transfers. This can be avoided to reduce the gas cost, by implementing delayed
+     * transfers. This might be considered in the future, but to avoid increasing the complexity and since so far we
+     * operate on low gas-cost blockchains, we keep it as it is.
+     */
+
+    emit PolicyReplaced(rm, oldPolicy.id, newPolicy_);
+    return newPolicy_.id;
+  }
+
   function _validatePolicy(Policy.PolicyData memory policy) internal view {
     require(policy.id != 0 && policy.hash() == _policies[policy.id], "Policy not found");
+  }
+
+  function _makePolicyId(IRiskModule rm, uint96 internalId) internal pure returns (uint256) {
+    return (uint256(uint160(address(rm))) << 96) + internalId;
   }
 
   function expirePolicy(Policy.PolicyData calldata policy) external override whenNotPaused {
@@ -526,21 +574,14 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
     IRiskModule rm = policy.riskModule;
     require(expired || address(rm) == _msgSender(), "Only the RM can resolve policies");
     require(payout == 0 || policy.expiration > block.timestamp, "Can't pay expired policy");
-    ComponentStatus compStatus = _rmStatus(rm);
-    require(
-      compStatus == ComponentStatus.active || compStatus == ComponentStatus.deprecated,
-      "Module must be active or deprecated to process resolutions"
-    );
+    _requireCompActiveOrDeprecated(address(rm), ComponentKind.riskModule);
+
     require(payout <= policy.payout, "payout > policy.payout");
 
     bool customerWon = payout > 0;
 
     IPremiumsAccount pa = rm.premiumsAccount();
-    compStatus = _paStatus(pa);
-    require(
-      compStatus == ComponentStatus.active || compStatus == ComponentStatus.deprecated,
-      "PremiumsAccount must be active or deprecated to process resolutions"
-    );
+    _requireCompActiveOrDeprecated(address(pa), ComponentKind.premiumsAccount);
     // Effects
     delete _policies[policy.id];
     // Interactions

--- a/contracts/PremiumsAccount.sol
+++ b/contracts/PremiumsAccount.sol
@@ -477,12 +477,10 @@ contract PremiumsAccount is IPremiumsAccount, Reserve {
     if (policy.srScr > 0) _seniorEtk.lockScr(policy.srScr, policy.srInterestRate());
   }
 
-  function policyReplaced(Policy.PolicyData memory oldPolicy, Policy.PolicyData memory newPolicy)
-    external
-    override
-    onlyPolicyPool
-    whenNotPaused
-  {
+  function policyReplaced(
+    Policy.PolicyData memory oldPolicy,
+    Policy.PolicyData memory newPolicy
+  ) external override onlyPolicyPool whenNotPaused {
     int256 diff = int256(oldPolicy.srInterestRate()) - int256(newPolicy.srInterestRate());
     require(SignedMath.abs(diff) < 1e14, "Interest rate can't change");
     diff = int256(oldPolicy.jrInterestRate()) - int256(newPolicy.jrInterestRate());

--- a/contracts/PremiumsAccount.sol
+++ b/contracts/PremiumsAccount.sol
@@ -481,10 +481,14 @@ contract PremiumsAccount is IPremiumsAccount, Reserve {
     Policy.PolicyData memory oldPolicy,
     Policy.PolicyData memory newPolicy
   ) external override onlyPolicyPool whenNotPaused {
-    int256 diff = int256(oldPolicy.srInterestRate()) - int256(newPolicy.srInterestRate());
-    require(SignedMath.abs(diff) < 1e14, "Interest rate can't change");
-    diff = int256(oldPolicy.jrInterestRate()) - int256(newPolicy.jrInterestRate());
-    require(SignedMath.abs(diff) < 1e14, "Interest rate can't change");
+    if (oldPolicy.srScr > 0 && newPolicy.srScr > 0) {
+      int256 diff = int256(oldPolicy.srInterestRate()) - int256(newPolicy.srInterestRate());
+      require(SignedMath.abs(diff) < 1e14, "Interest rate can't change");
+    }
+    if (oldPolicy.jrScr > 0 && newPolicy.jrScr > 0) {
+      int256 diff = int256(oldPolicy.jrInterestRate()) - int256(newPolicy.jrInterestRate());
+      require(SignedMath.abs(diff) < 1e14, "Interest rate can't change");
+    }
     /*
      * Supporting interest rate change is possible, but it would require complex computations.
      * If new IR > old IR, then we must adjust positivelly to accrue the interests not accrued

--- a/contracts/RiskModule.sol
+++ b/contracts/RiskModule.sol
@@ -359,7 +359,7 @@ abstract contract RiskModule is IRiskModule, PolicyPoolComponent {
   }
 
   /**
-   * @dev Called from child contracts to create policies (after they validated the pricing).
+   * @dev Called from child contracts to replace policies (after they validated the pricing).
    *      whenNotPaused validation must be done in the external method.
    *
    * @param payout The exposure (maximum payout) of the policy

--- a/contracts/RiskModule.sol
+++ b/contracts/RiskModule.sol
@@ -333,7 +333,7 @@ abstract contract RiskModule is IRiskModule, PolicyPoolComponent {
     address onBehalfOf,
     uint96 internalId,
     Params memory params_
-  ) internal returns (Policy.PolicyData memory) {
+  ) internal returns (Policy.PolicyData memory policy) {
     if (premium == type(uint256).max) {
       premium = _getMinimumPremium(payout, lossProb, expiration, params_);
     }
@@ -351,11 +351,75 @@ abstract contract RiskModule is IRiskModule, PolicyPoolComponent {
       "Payer must allow caller to transfer the premium"
     );
     require(payout <= maxPayoutPerPolicy(), "RiskModule: Payout is more than maximum per policy");
-    Policy.PolicyData memory policy = Policy.initialize(this, params_, premium, payout, lossProb, expiration);
+    policy = Policy.initialize(this, params_, premium, payout, lossProb, expiration, now_);
     _activeExposure += policy.payout;
     require(_activeExposure <= exposureLimit(), "RiskModule: Exposure limit exceeded");
-    uint256 policyId = _policyPool.newPolicy(policy, payer, onBehalfOf, internalId);
-    policy.id = policyId;
+    policy.id = _policyPool.newPolicy(policy, payer, onBehalfOf, internalId);
+    return policy;
+  }
+
+  /**
+   * @dev Called from child contracts to create policies (after they validated the pricing).
+   *      whenNotPaused validation must be done in the external method.
+   *
+   * @param payout The exposure (maximum payout) of the policy
+   * @param premium The premium that will be paid by the policyHolder
+   * @param lossProb The probability of having to pay the maximum payout (wad)
+   * @param payer The account that pays for the premium
+   * @param expiration The expiration of the policy (timestamp)
+   * @param internalId An id that's unique within this module and it will be used to identify the policy
+   * @param params_ Params to use to create the new policy
+   */
+  function _replacePolicy(
+    Policy.PolicyData calldata oldPolicy,
+    uint256 payout,
+    uint256 premium,
+    uint256 lossProb,
+    uint40 expiration,
+    address payer,
+    uint96 internalId,
+    Params memory params_
+  ) internal virtual returns (Policy.PolicyData memory policy) {
+    if (premium == type(uint256).max) {
+      premium = _getMinimumPremium(payout, lossProb, expiration, params_);
+    }
+    require(premium < payout, "Premium must be less than payout");
+    require(oldPolicy.expiration > uint40(block.timestamp), "Old policy is expired");
+    require(
+      expiration >= oldPolicy.expiration &&
+        payout >= oldPolicy.payout &&
+        premium >= oldPolicy.premium,
+      "Policy replacement must be greater or equal than old policy"
+    );
+    require(
+      ((expiration - oldPolicy.start) / 3600) < _params.maxDuration,
+      "Policy exceeds max duration"
+    );
+    require(
+      _policyPool.currency().allowance(payer, address(_policyPool)) >=
+        (premium - oldPolicy.premium),
+      "You must allow ENSURO to transfer the premium"
+    );
+    require(
+      payer == _msgSender() ||
+        _policyPool.currency().allowance(payer, _msgSender()) >= (premium - oldPolicy.premium),
+      "Payer must allow caller to transfer the premium"
+    );
+    require(payout <= maxPayoutPerPolicy(), "RiskModule: Payout is more than maximum per policy");
+    policy = Policy.initialize(
+      this,
+      params_,
+      premium,
+      payout,
+      lossProb,
+      expiration,
+      oldPolicy.start
+    );
+
+    _activeExposure += policy.payout - oldPolicy.payout;
+    require(_activeExposure <= exposureLimit(), "RiskModule: Exposure limit exceeded");
+
+    policy.id = _policyPool.replacePolicy(oldPolicy, policy, payer, internalId);
     return policy;
   }
 

--- a/contracts/interfaces/IPolicyPool.sol
+++ b/contracts/interfaces/IPolicyPool.sol
@@ -25,11 +25,7 @@ interface IPolicyPool {
    * @param oldPolicyId The id of the replaced policy.
    * @param newPolicy The {Policy-PolicyData} struct with all the immutable fields of the policy.
    */
-  event PolicyReplaced(
-    IRiskModule indexed riskModule,
-    uint256 indexed oldPolicyId,
-    Policy.PolicyData newPolicy
-  );
+  event PolicyReplaced(IRiskModule indexed riskModule, uint256 indexed oldPolicyId, Policy.PolicyData newPolicy);
 
   /**
    * @dev Event emitted every time a policy is removed from the pool. If the policy expired, the `payout` is 0,

--- a/contracts/interfaces/IPolicyPool.sol
+++ b/contracts/interfaces/IPolicyPool.sol
@@ -23,9 +23,9 @@ interface IPolicyPool {
    *
    * @param riskModule The risk module that created the policy
    * @param oldPolicyId The id of the replaced policy.
-   * @param newPolicy The {Policy-PolicyData} struct with all the immutable fields of the policy.
+   * @param newPolicyId The id of the new policy.
    */
-  event PolicyReplaced(IRiskModule indexed riskModule, uint256 indexed oldPolicyId, Policy.PolicyData newPolicy);
+  event PolicyReplaced(IRiskModule indexed riskModule, uint256 indexed oldPolicyId, uint256 indexed newPolicyId);
 
   /**
    * @dev Event emitted every time a policy is removed from the pool. If the policy expired, the `payout` is 0,

--- a/contracts/interfaces/IPolicyPool.sol
+++ b/contracts/interfaces/IPolicyPool.sol
@@ -4,9 +4,43 @@ pragma solidity 0.8.16;
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {Policy} from "../Policy.sol";
 import {IEToken} from "./IEToken.sol";
+import {IRiskModule} from "./IRiskModule.sol";
 import {IAccessManager} from "./IAccessManager.sol";
 
 interface IPolicyPool {
+  /**
+   * @dev Event emitted every time a new policy is added to the pool. Contains all the data about the policy that is
+   * later required for doing operations with the policy like resolution or expiration.
+   *
+   * @param riskModule The risk module that created the policy
+   * @param policy The {Policy-PolicyData} struct with all the immutable fields of the policy.
+   */
+  event NewPolicy(IRiskModule indexed riskModule, Policy.PolicyData policy);
+
+  /**
+   * @dev Event emitted every time a new policy replaces an old Policy Contains all the data about the policy that is
+   * later required for doing operations with the policy like resolution or expiration.
+   *
+   * @param riskModule The risk module that created the policy
+   * @param oldPolicyId The id of the replaced policy.
+   * @param newPolicy The {Policy-PolicyData} struct with all the immutable fields of the policy.
+   */
+  event PolicyReplaced(
+    IRiskModule indexed riskModule,
+    uint256 indexed oldPolicyId,
+    Policy.PolicyData newPolicy
+  );
+
+  /**
+   * @dev Event emitted every time a policy is removed from the pool. If the policy expired, the `payout` is 0,
+   * otherwise is the amount transferred to the policyholder.
+   *
+   * @param riskModule The risk module where that created the policy initially.
+   * @param policyId The unique id of the policy
+   * @param payout The payout that has been paid to the policy holder. 0 when the policy expired.
+   */
+  event PolicyResolved(IRiskModule indexed riskModule, uint256 indexed policyId, uint256 payout);
+
   /**
    * @dev Reference to the main currency (ERC20) used in the protocol
    * @return The address of the currency (e.g. USDC) token used in the protocol
@@ -39,15 +73,41 @@ interface IPolicyPool {
    * (see Premium Split in the docs)
    *
    * @param policy A policy created with {Policy-initialize}
-   * @param caller The pricer that's creating the policy and will pay for the premium
-   * @param policyHolder The address of the policy holder and the payer of the premiums
+   * @param payer The address that will pay for the premium
+   * @param policyHolder The address of the policy holder
    * @param internalId A unique id within the RiskModule, that will be used to compute the policy id
    * @return The policy id, identifying the NFT and the policy
    */
   function newPolicy(
     Policy.PolicyData memory policy,
-    address caller,
+    address payer,
     address policyHolder,
+    uint96 internalId
+  ) external returns (uint256);
+
+  /**
+   * @dev Replaces a policy with another. Must be called from an active RiskModule
+   *
+   * Requirements:
+   * - `msg.sender` must be an active RiskModule
+   * - `caller` approved the spending of `currency()` for at least `newPolicy_.premium - oldPolicy.premium`
+   * - `internalId` must be unique within `policy.riskModule` and not used before
+   *
+   * Events:
+   * - {PolicyPool-PolicyReplaced}: with all the details about the policy
+   * - {ERC20-Transfer}: does several transfers from caller address to the different receivers of the premium
+   * (see Premium Split in the docs)
+   *
+   * @param oldPolicy A policy created previously and not expired
+   * @param newPolicy_ A policy created with {Policy-initialize}
+   * @param payer The address that will pay for the premium
+   * @param internalId A unique id within the RiskModule, that will be used to compute the policy id
+   * @return The policy id, identifying the NFT and the policy
+   */
+  function replacePolicy(
+    Policy.PolicyData memory oldPolicy,
+    Policy.PolicyData memory newPolicy_,
+    address payer,
     uint96 internalId
   ) external returns (uint256);
 

--- a/contracts/interfaces/IPremiumsAccount.sol
+++ b/contracts/interfaces/IPremiumsAccount.sol
@@ -38,8 +38,7 @@ interface IPremiumsAccount {
    * @param oldPolicy The policy to replace (created in a previous transaction)
    * @param newPolicy The policy that will replace the old one (created in this transaction)
    */
-  function policyReplaced(Policy.PolicyData memory oldPolicy, Policy.PolicyData memory newPolicy)
-    external;
+  function policyReplaced(Policy.PolicyData memory oldPolicy, Policy.PolicyData memory newPolicy) external;
 
   /**
    * @dev The PremiumsAccount is notified that the policy was resolved and issues the payout to the policyHolder.

--- a/contracts/interfaces/IPremiumsAccount.sol
+++ b/contracts/interfaces/IPremiumsAccount.sol
@@ -25,6 +25,23 @@ interface IPremiumsAccount {
   function policyCreated(Policy.PolicyData memory policy) external;
 
   /**
+   * @dev Replaces a policy with another in PremiumsAccount. Stores the pure premiums difference and
+   * re-locks the aditional funds from junior and senior eTokens.
+   *
+   * Requirements:
+   * - Must be called by `policyPool()`
+   *
+   * Events:
+   * - {EToken-SCRUnlocked}
+   * - {EToken-SCRLocked}
+   *
+   * @param oldPolicy The policy to replace (created in a previous transaction)
+   * @param newPolicy The policy that will replace the old one (created in this transaction)
+   */
+  function policyReplaced(Policy.PolicyData memory oldPolicy, Policy.PolicyData memory newPolicy)
+    external;
+
+  /**
    * @dev The PremiumsAccount is notified that the policy was resolved and issues the payout to the policyHolder.
    *
    * Requirements:

--- a/contracts/mocks/InterfaceIdCalculator.sol
+++ b/contracts/mocks/InterfaceIdCalculator.sol
@@ -10,6 +10,7 @@ import {IPolicyPool} from "../interfaces/IPolicyPool.sol";
 import {IPolicyPoolComponent} from "../interfaces/IPolicyPoolComponent.sol";
 import {IEToken} from "../interfaces/IEToken.sol";
 import {IRiskModule} from "../interfaces/IRiskModule.sol";
+import {IPolicyHolder} from "../interfaces/IPolicyHolder.sol";
 import {IPremiumsAccount} from "../interfaces/IPremiumsAccount.sol";
 import {ILPWhitelist} from "../interfaces/ILPWhitelist.sol";
 import {IAccessManager} from "../interfaces/IAccessManager.sol";
@@ -29,4 +30,5 @@ contract InterfaceIdCalculator {
   bytes4 public constant ILPWHITELIST_INTERFACEID = type(ILPWhitelist).interfaceId;
   bytes4 public constant IACCESSMANAGER_INTERFACEID = type(IAccessManager).interfaceId;
   bytes4 public constant IASSETMANAGER_INTERFACEID = type(IAssetManager).interfaceId;
+  bytes4 public constant IPOLICYHOLDER_INTERFACEID = type(IPolicyHolder).interfaceId;
 }

--- a/contracts/mocks/PolicyPoolMock.sol
+++ b/contracts/mocks/PolicyPoolMock.sol
@@ -57,6 +57,8 @@ contract PolicyPoolMock is IPolicyPool {
   ) external override returns (uint256) {
     newPolicy_.id = (uint256(uint160(address(newPolicy_.riskModule))) << 96) + internalId;
     policyHashes[newPolicy_.id] = newPolicy_.hash();
+    IRiskModule rm = oldPolicy.riskModule;
+    emit NewPolicy(rm, newPolicy_);
     emit PolicyReplaced(IRiskModule(msg.sender), oldPolicy.id, newPolicy_.id);
     return newPolicy_.id;
   }

--- a/contracts/mocks/PolicyPoolMock.sol
+++ b/contracts/mocks/PolicyPoolMock.sol
@@ -52,7 +52,7 @@ contract PolicyPoolMock is IPolicyPool {
   function replacePolicy(
     Policy.PolicyData memory oldPolicy,
     Policy.PolicyData memory newPolicy_,
-    address, /* payer */
+    address /* payer */,
     uint96 internalId
   ) external override returns (uint256) {
     newPolicy_.id = (uint256(uint160(address(newPolicy_.riskModule))) << 96) + internalId;

--- a/contracts/mocks/PolicyPoolMock.sol
+++ b/contracts/mocks/PolicyPoolMock.sol
@@ -57,7 +57,7 @@ contract PolicyPoolMock is IPolicyPool {
   ) external override returns (uint256) {
     newPolicy_.id = (uint256(uint160(address(newPolicy_.riskModule))) << 96) + internalId;
     policyHashes[newPolicy_.id] = newPolicy_.hash();
-    emit PolicyReplaced(IRiskModule(msg.sender), oldPolicy.id, newPolicy_);
+    emit PolicyReplaced(IRiskModule(msg.sender), oldPolicy.id, newPolicy_.id);
     return newPolicy_.id;
   }
 

--- a/contracts/mocks/PolicyPoolMock.sol
+++ b/contracts/mocks/PolicyPoolMock.sol
@@ -20,9 +20,6 @@ contract PolicyPoolMock is IPolicyPool {
   mapping(uint256 => Policy.PolicyData) internal policies;
   mapping(uint256 => bytes32) internal policyHashes;
 
-  event NewPolicy(IRiskModule indexed riskModule, Policy.PolicyData policy);
-  event PolicyResolved(IRiskModule indexed riskModule, uint256 indexed policyId, uint256 payout);
-
   constructor(IERC20Metadata currency_, IAccessManager access_) {
     _currency = currency_;
     _access = access_;
@@ -42,7 +39,7 @@ contract PolicyPoolMock is IPolicyPool {
 
   function newPolicy(
     Policy.PolicyData memory policy,
-    address /* caller */,
+    address /* payer */,
     address /* policyHolder */,
     uint96 internalId
   ) external override returns (uint256) {
@@ -50,6 +47,18 @@ contract PolicyPoolMock is IPolicyPool {
     policyHashes[policy.id] = policy.hash();
     emit NewPolicy(IRiskModule(msg.sender), policy);
     return policy.id;
+  }
+
+  function replacePolicy(
+    Policy.PolicyData memory oldPolicy,
+    Policy.PolicyData memory newPolicy_,
+    address, /* payer */
+    uint96 internalId
+  ) external override returns (uint256) {
+    newPolicy_.id = (uint256(uint160(address(newPolicy_.riskModule))) << 96) + internalId;
+    policyHashes[newPolicy_.id] = newPolicy_.hash();
+    emit PolicyReplaced(IRiskModule(msg.sender), oldPolicy.id, newPolicy_);
+    return newPolicy_.id;
   }
 
   function _resolvePolicy(Policy.PolicyData memory policy, uint256 payout) internal {
@@ -98,9 +107,18 @@ contract PolicyPoolMock is IPolicyPool {
     uint256 premium,
     uint256 payout,
     uint256 lossProb,
-    uint40 expiration
+    uint40 expiration,
+    uint40 start
   ) external {
-    Policy.PolicyData memory policy = Policy.initialize(riskModule, rmParams, premium, payout, lossProb, expiration);
+    Policy.PolicyData memory policy = Policy.initialize(
+      riskModule,
+      rmParams,
+      premium,
+      payout,
+      lossProb,
+      expiration,
+      start == 0 ? uint40(block.timestamp) : start
+    );
 
     emit NewPolicy(riskModule, policy);
   }

--- a/contracts/mocks/RiskModuleMock.sol
+++ b/contracts/mocks/RiskModuleMock.sol
@@ -58,8 +58,21 @@ contract RiskModuleMock is RiskModule {
     return _newPolicy(payout, premium, lossProb, expiration, payer, onBehalfOf, internalId).id;
   }
 
+  function newPolicyRaw(
+    Policy.PolicyData memory policy,
+    address payer,
+    address policyHolder,
+    uint96 internalId
+  ) external returns (uint256) {
+    return _policyPool.newPolicy(policy, payer, policyHolder, internalId);
+  }
+
   function resolvePolicy(Policy.PolicyData calldata policy, uint256 payout) external onlyComponentRole(RESOLVER_ROLE) {
     _policyPool.resolvePolicy(policy, payout);
+  }
+
+  function resolvePolicyRaw(Policy.PolicyData calldata policy, uint256 payout) external {
+    return _policyPool.resolvePolicy(policy, payout);
   }
 
   function replacePolicy(
@@ -72,5 +85,14 @@ contract RiskModuleMock is RiskModule {
   ) external whenNotPaused onlyComponentRole(REPLACER_ROLE) returns (uint256) {
     address onBehalfOf = IERC721(address(_policyPool)).ownerOf(oldPolicy.id);
     return _replacePolicy(oldPolicy, payout, premium, lossProb, expiration, onBehalfOf, internalId, params()).id;
+  }
+
+  function replacePolicyRaw(
+    Policy.PolicyData memory oldPolicy,
+    Policy.PolicyData memory newPolicy_,
+    address payer,
+    uint96 internalId
+  ) external returns (uint256) {
+    return _policyPool.replacePolicy(oldPolicy, newPolicy_, payer, internalId);
   }
 }

--- a/contracts/mocks/RiskModuleMock.sol
+++ b/contracts/mocks/RiskModuleMock.sol
@@ -71,16 +71,6 @@ contract RiskModuleMock is RiskModule {
     uint96 internalId
   ) external whenNotPaused onlyComponentRole(REPLACER_ROLE) returns (uint256) {
     address onBehalfOf = IERC721(address(_policyPool)).ownerOf(oldPolicy.id);
-    return
-      _replacePolicy(
-        oldPolicy,
-        payout,
-        premium,
-        lossProb,
-        expiration,
-        onBehalfOf,
-        internalId,
-        params()
-      ).id;
+    return _replacePolicy(oldPolicy, payout, premium, lossProb, expiration, onBehalfOf, internalId, params()).id;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9157,9 +9157,9 @@
       "dev": true
     },
     "node_modules/solidity-coverage": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.8.8.tgz",
-      "integrity": "sha512-7RN6/8YAFMQNeMdSulARtE0VC5JitBAUMwvkr10FkOK+nux5q+WykrgSZntkWrX/VHzRa096P4OOViO0T9Q9Cw==",
+      "version": "0.8.9",
+      "resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.8.9.tgz",
+      "integrity": "sha512-ZhPsxlsLkYyzgwoVGh8RBN2ju7JVahvMkk+8RBVc0vP/3UNq88GzvL8kvbuY48lVIRL8eQjJ+0X8al2Bu9/2iQ==",
       "dev": true,
       "peer": true,
       "dependencies": {

--- a/prototype/ensuro.py
+++ b/prototype/ensuro.py
@@ -1245,7 +1245,7 @@ class PolicyPool(ERC721Token):
 
     @external
     def replace_policy(self, old_policy, new_policy, payer, internal_id):
-        require(old_policy.id in self.policies, "The old policy doesn't exist")
+        require(old_policy.id in self.policies, "Policy not found")
         old_policy = self.policies[old_policy.id]  # To make sure is the same, in solidity check with hash
         require(new_policy.start == old_policy.start, "Both policies must have the same starting date")
         require(

--- a/prototype/ensuro.py
+++ b/prototype/ensuro.py
@@ -310,6 +310,56 @@ class RiskModule(AccessControlContract):
         assert policy.id > 0
         return policy
 
+    @external
+    def replace_policy(self, old_policy, payout, premium, loss_prob, expiration, payer, internal_id):
+        assert type(loss_prob) == Wad, "Loss prob MUST be wad"
+        start = old_policy.start
+        require(
+            payout >= old_policy.payout and expiration >= old_policy.expiration,
+            "Policy replacement must be greater or equal than old policy",
+        )
+        if premium is None:
+            premium = self.get_minimum_premium(payout, loss_prob, expiration)
+
+        require(premium < payout, "Premium must be less than payout")
+        require(expiration > start, "Expiration must be in the future")
+        require(((expiration - start) / SECONDS_IN_HOUR) < self.max_duration, "Policy exceeds max duration")
+        require(
+            self.policy_pool.currency.allowance(payer, self.policy_pool.contract_id)
+            >= (old_policy.premium - premium),
+            "You must allow ENSURO to transfer the premium",
+        )
+        require(
+            self._running_as == payer
+            or self.policy_pool.currency.allowance(payer, self._running_as) >= (old_policy.premium - premium),
+            "Payer must allow PRICER to transfer the premium",
+        )
+
+        policy = Policy(
+            id=-1,
+            risk_module=self,
+            payout=payout,
+            premium=premium,
+            loss_prob=loss_prob,
+            start=start,
+            expiration=expiration,
+        )
+
+        require(
+            policy.payout <= self.max_payout_per_policy,
+            f"Policy Payout is more than maximum: {policy.payout} > maximum {self.max_payout_per_policy}",
+        )
+        active_exposure = self.active_exposure + policy.payout - old_policy.payout
+        require(
+            active_exposure <= self.exposure_limit,
+            "RiskModule: Exposure limit exceeded",
+        )
+        self.active_exposure = active_exposure
+
+        policy.id = self.policy_pool.replace_policy(old_policy, policy, payer, internal_id)
+        assert policy.id > 0
+        return policy
+
     def get_minimum_premium(self, payout, loss_prob, expiration):
         return self.get_minimum_premium_composition(payout, loss_prob, expiration).total
 
@@ -1045,6 +1095,22 @@ class PremiumsAccount(ReserveMixin, AccessControlContract):
             self.junior_etk.lock_scr(policy.jr_scr, policy.jr_interest_rate)
 
     @external
+    def policy_replaced(self, old_policy, new_policy):
+        require(
+            new_policy.sr_interest_rate.equal(old_policy.sr_interest_rate, 4)
+            and new_policy.jr_interest_rate.equal(old_policy.jr_interest_rate, 4),
+            "Interest rate can't change",
+        )
+        # Supporting interest rate change is possible, but it would require complex computations.
+        # If new IR > old IR, then we must adjust positivelly to accrue the interests not accrued
+        # If new IR < old IR, then we must adjust negativelly to substract the interests accrued in excess
+        self.active_pure_premiums += new_policy.pure_premium - old_policy.pure_premium
+        self.senior_etk.unlock_scr(old_policy.sr_scr, old_policy.sr_interest_rate, Wad(0))
+        self.senior_etk.lock_scr(new_policy.sr_scr, new_policy.sr_interest_rate)
+        self.senior_etk.unlock_scr(old_policy.jr_scr, old_policy.jr_interest_rate, Wad(0))
+        self.senior_etk.lock_scr(new_policy.jr_scr, new_policy.jr_interest_rate)
+
+    @external
     def policy_resolved_with_payout(self, customer, policy, payout):
         self.active_pure_premiums -= policy.pure_premium
         borrow_from_scr = self._pay_from_premiums(payout - policy.pure_premium)
@@ -1175,7 +1241,66 @@ class PolicyPool(ERC721Token):
         return policy.id
 
     @external
+    def replace_policy(self, old_policy, new_policy, payer, internal_id):
+        require(old_policy == self.policies[old_policy.id], "The old policy doesn't exist")
+        require(new_policy.start == old_policy.start, "Both policies must have the same starting date")
+        require(
+            old_policy.payout <= new_policy.payout
+            and old_policy.pure_premium <= new_policy.pure_premium
+            and old_policy.ensuro_commission <= new_policy.ensuro_commission
+            and old_policy.jr_coc <= new_policy.jr_coc
+            and old_policy.sr_coc <= new_policy.sr_coc
+            and old_policy.jr_scr <= new_policy.jr_scr
+            and old_policy.sr_scr <= new_policy.sr_scr
+            and old_policy.partner_commission <= new_policy.partner_commission
+            and old_policy.expiration <= new_policy.expiration
+            and old_policy.risk_module == new_policy.risk_module,
+            "New policy must be greater or equal than old policy",
+        )
+        new_policy.id = new_policy.risk_module.make_policy_id(internal_id)
+        policy_holder = self.owner_of(old_policy.id)
+        self.mint(policy_holder, new_policy.id)
+
+        pa = new_policy.risk_module.premiums_account
+        pa.policy_replaced(old_policy, new_policy)
+
+        self.policies[new_policy.id] = new_policy
+        if new_policy.pure_premium > old_policy.pure_premium:
+            self.currency.transfer_from(
+                self.contract_id, payer, pa, new_policy.pure_premium - old_policy.pure_premium
+            )
+        if new_policy.sr_coc > old_policy.sr_coc:
+            self.currency.transfer_from(
+                self.contract_id, payer, pa.senior_etk, new_policy.sr_coc - old_policy.sr_coc
+            )
+        if new_policy.jr_coc > old_policy.jr_coc:
+            self.currency.transfer_from(
+                self.contract_id, payer, pa.junior_etk, new_policy.jr_coc - old_policy.jr_coc
+            )
+        if new_policy.ensuro_commission > old_policy.ensuro_commission:
+            self.currency.transfer_from(
+                self.contract_id,
+                payer,
+                self.treasury,
+                new_policy.ensuro_commission - old_policy.ensuro_commission,
+            )
+        if (
+            new_policy.partner_commission
+            and new_policy.risk_module.wallet != policy_holder
+            and new_policy.partner_commission > old_policy.partner_commission
+        ):
+            self.currency.transfer_from(
+                self.contract_id,
+                payer,
+                new_policy.risk_module.wallet,
+                new_policy.partner_commission - old_policy.partner_commission,
+            )
+        del self.policies[old_policy.id]
+        return new_policy.id
+
+    @external
     def expire_policy(self, policy_id):
+        require(policy_id in self.policies, "Policy not found")
         policy = self.policies[policy_id]
         require(policy.expiration <= time_control.now, "Policy not expired yet")
         return self.resolve_policy(policy_id, Wad(0))
@@ -1183,12 +1308,14 @@ class PolicyPool(ERC721Token):
     @external
     def expire_policies(self, policy_ids):
         for policy_id in policy_ids:
+            require(policy_id in self.policies, "Policy not found")
             policy = self.policies[policy_id]
             require(policy.expiration <= time_control.now, "Policy not expired yet")
             self.resolve_policy(policy_id, Wad(0))
 
     @external
     def resolve_policy(self, policy_id, payout):
+        require(policy_id in self.policies, "Policy not found")
         policy = self.policies[policy_id]
         if isinstance(payout, bool):
             payout = policy.payout if payout is True else Wad(0)

--- a/prototype/ensuro.py
+++ b/prototype/ensuro.py
@@ -313,7 +313,7 @@ class RiskModule(AccessControlContract):
     @external
     @only_component_role("REPLACER_ROLE")
     def replace_policy(self, old_policy, payout, premium, loss_prob, expiration, payer, internal_id):
-        assert type(loss_prob) == Wad, "Loss prob MUST be wad"
+        assert isinstance(loss_prob, Wad), "Loss prob MUST be wad"
         start = old_policy.start
         require(old_policy.expiration > time_control.now, "Old policy is expired")
         if premium is None:
@@ -329,7 +329,7 @@ class RiskModule(AccessControlContract):
         require(((expiration - start) / SECONDS_IN_HOUR) < self.max_duration, "Policy exceeds max duration")
         require(
             self.policy_pool.currency.allowance(payer, self.policy_pool.contract_id)
-            >= (old_policy.premium - premium),
+            >= (premium - old_policy.premium),
             "You must allow ENSURO to transfer the premium",
         )
         require(

--- a/prototype/wrappers.py
+++ b/prototype/wrappers.py
@@ -543,8 +543,8 @@ class TrustfulRiskModule(RiskModule):
         if "premium" not in kwargs:
             kwargs["premium"] = MAX_UINT
         receipt = self.replace_policy_(*args, **kwargs)
-        if "PolicyReplaced" in receipt.events:
-            policy_data = receipt.events["PolicyReplaced"]["newPolicy"]
+        if "NewPolicy" in receipt.events:
+            policy_data = receipt.events["NewPolicy"]["policy"]
             policy = Policy.from_policy_data(policy_data, address_book=self.provider.address_book)
             policy_db.add_policy(self.policy_pool.contract.address, policy)
             return policy

--- a/prototype/wrappers.py
+++ b/prototype/wrappers.py
@@ -545,7 +545,7 @@ class TrustfulRiskModule(RiskModule):
         receipt = self.replace_policy_(*args, **kwargs)
         if "PolicyReplaced" in receipt.events:
             policy_data = receipt.events["PolicyReplaced"]["newPolicy"]
-            policy = Policy(*policy_data, address_book=self.provider.address_book)
+            policy = Policy.from_policy_data(policy_data, address_book=self.provider.address_book)
             policy_db.add_policy(self.policy_pool.contract.address, policy)
             return policy
         else:

--- a/test/test-add-remove-change-components.js
+++ b/test/test-add-remove-change-components.js
@@ -88,9 +88,7 @@ describe("Test add, remove and change status of PolicyPool components", function
     expect(await pool.getComponentStatus(etk)).to.be.equal(ST_DEPRECATED);
 
     // When deprecated, deposits aren't allowed, but withdrawals are allowed
-    await expect(pool.connect(lp).deposit(etk, _A(200))).to.be.revertedWith(
-      "Component not found or not active"
-    );
+    await expect(pool.connect(lp).deposit(etk, _A(200))).to.be.revertedWith("Component not found or not active");
     await expect(pool.connect(lp).withdraw(etk, _A(200))).not.to.be.reverted;
 
     // Only GUARDIAN can suspend
@@ -101,9 +99,7 @@ describe("Test add, remove and change status of PolicyPool components", function
     expect(await pool.getComponentStatus(etk)).to.be.equal(ST_SUSPENDED);
 
     // When suspended, withdrawals are not allowed
-    await expect(pool.connect(lp).withdraw(etk, _A(100))).to.be.revertedWith(
-      "Component must be active or deprecated"
-    );
+    await expect(pool.connect(lp).withdraw(etk, _A(100))).to.be.revertedWith("Component must be active or deprecated");
 
     // Only LEVEL1 can reactivate
     await expect(pool.connect(guardian).changeComponentStatus(etk, ST_ACTIVE)).to.be.revertedWith(
@@ -128,9 +124,7 @@ describe("Test add, remove and change status of PolicyPool components", function
     await expect(pool.connect(level1).removeComponent(etk)).not.to.be.reverted;
     expect(await pool.getComponentStatus(etk)).to.be.equal(ST_INACTIVE);
 
-    await expect(pool.connect(lp).deposit(etk, _A(200))).to.be.revertedWith(
-      "Component is not of the right kind"
-    );
+    await expect(pool.connect(lp).deposit(etk, _A(200))).to.be.revertedWith("Component is not of the right kind");
   });
 
   it("Change status and remove RiskModule", async function () {
@@ -148,10 +142,10 @@ describe("Test add, remove and change status of PolicyPool components", function
     expect(await pool.getComponentStatus(rm)).to.be.equal(ST_DEPRECATED);
 
     // When deprecated can't create policy
-      rm.connect(cust).newPolicy(_A(36), _A(1), _W(1 / 37), start + 3600, cust, 2)
-    await expect(
-      rm.connect(cust).newPolicy(_A(36), _A(1), _W(1 / 37), start + 3600, cust, 2)
-    ).to.be.revertedWith("Component not found or not active");
+    rm.connect(cust).newPolicy(_A(36), _A(1), _W(1 / 37), start + 3600, cust, 2);
+    await expect(rm.connect(cust).newPolicy(_A(36), _A(1), _W(1 / 37), start + 3600, cust, 2)).to.be.revertedWith(
+      "Component not found or not active"
+    );
 
     // But policies can be resolved
     await expect(rm.connect(cust).resolvePolicy([...policy], _A(10))).not.to.be.reverted;
@@ -171,12 +165,12 @@ describe("Test add, remove and change status of PolicyPool components", function
     expect(await pool.getComponentStatus(rm)).to.be.equal(ST_SUSPENDED);
 
     // When suspended, policy creation / resolutions are not allowed
-    await expect(rm.connect(cust).resolvePolicy(policy, _A(10))).to.be.revertedWith(
+    await expect(rm.connect(cust).resolvePolicy([...policy], _A(10))).to.be.revertedWith(
       "Component must be active or deprecated"
     );
-    await expect(
-      rm.connect(cust).newPolicy(_A(36), _A(1), _W(1 / 37), start + 3600, cust, 4)
-    ).to.be.revertedWith("Component not found or not active");
+    await expect(rm.connect(cust).newPolicy(_A(36), _A(1), _W(1 / 37), start + 3600, cust, 4)).to.be.revertedWith(
+      "Component not found or not active"
+    );
 
     // Can't be removed if not deprecated before, or if has active policies
     await expect(pool.connect(level1).removeComponent(rm)).to.be.revertedWith("Component not deprecated");
@@ -190,9 +184,9 @@ describe("Test add, remove and change status of PolicyPool components", function
     await expect(pool.connect(level1).removeComponent(rm)).not.to.be.reverted;
     expect(await pool.getComponentStatus(rm)).to.be.equal(ST_INACTIVE);
 
-    await expect(
-      rm.connect(cust).newPolicy(_A(36), _A(1), _W(1 / 37), start + 3600, cust, 5)
-    ).to.be.revertedWith("Component is not of the right kind");
+    await expect(rm.connect(cust).newPolicy(_A(36), _A(1), _W(1 / 37), start + 3600, cust, 5)).to.be.revertedWith(
+      "Component is not of the right kind"
+    );
   });
 
   it("Change status and remove PremiumsAccount", async function () {
@@ -210,9 +204,9 @@ describe("Test add, remove and change status of PolicyPool components", function
     expect(await pool.getComponentStatus(premiumsAccount)).to.be.equal(ST_DEPRECATED);
 
     // When deprecated can't create policy
-    await expect(
-      rm.connect(cust).newPolicy(_A(36), _A(1), _W(1 / 37), start + 3600, cust, 2)
-    ).to.be.revertedWith("Component not found or not active");
+    await expect(rm.connect(cust).newPolicy(_A(36), _A(1), _W(1 / 37), start + 3600, cust, 2)).to.be.revertedWith(
+      "Component not found or not active"
+    );
 
     // But policies can be resolved
     await expect(rm.connect(cust).resolvePolicy([...policy], _A(10))).not.to.be.reverted;
@@ -229,12 +223,12 @@ describe("Test add, remove and change status of PolicyPool components", function
     expect(await pool.getComponentStatus(premiumsAccount)).to.be.equal(ST_SUSPENDED);
 
     // When suspended, policy creation / resolutions are not allowed
-    await expect(rm.connect(cust).resolvePolicy(policy, _A(10))).to.be.revertedWith(
+    await expect(rm.connect(cust).resolvePolicy([...policy], _A(10))).to.be.revertedWith(
       "Component must be active or deprecated"
     );
-    await expect(
-      rm.connect(cust).newPolicy(_A(36), _A(1), _W(1 / 37), start + 3600, cust, 4)
-    ).to.be.revertedWith("Component not found or not active");
+    await expect(rm.connect(cust).newPolicy(_A(36), _A(1), _W(1 / 37), start + 3600, cust, 4)).to.be.revertedWith(
+      "Component not found or not active"
+    );
 
     // Can't be removed if not deprecated before, or if has active policies
     await expect(pool.connect(level1).removeComponent(premiumsAccount)).to.be.revertedWith("Component not deprecated");
@@ -255,8 +249,8 @@ describe("Test add, remove and change status of PolicyPool components", function
     expect(borrowerRemovedEvt.args.defaultedDebt).to.be.equal(internalLoan);
     expect(await pool.getComponentStatus(premiumsAccount)).to.be.equal(ST_INACTIVE);
 
-    await expect(
-      rm.connect(cust).newPolicy(_A(36), _A(1), _W(1 / 37), start + 3600, cust, 5)
-    ).to.be.revertedWith("Component is not of the right kind");
+    await expect(rm.connect(cust).newPolicy(_A(36), _A(1), _W(1 / 37), start + 3600, cust, 5)).to.be.revertedWith(
+      "Component is not of the right kind"
+    );
   });
 });

--- a/test/test-add-remove-change-components.js
+++ b/test/test-add-remove-change-components.js
@@ -88,7 +88,9 @@ describe("Test add, remove and change status of PolicyPool components", function
     expect(await pool.getComponentStatus(etk)).to.be.equal(ST_DEPRECATED);
 
     // When deprecated, deposits aren't allowed, but withdrawals are allowed
-    await expect(pool.connect(lp).deposit(etk, _A(200))).to.be.revertedWith("eToken is not active");
+    await expect(pool.connect(lp).deposit(etk, _A(200))).to.be.revertedWith(
+      "Component not found or not active"
+    );
     await expect(pool.connect(lp).withdraw(etk, _A(200))).not.to.be.reverted;
 
     // Only GUARDIAN can suspend
@@ -100,7 +102,7 @@ describe("Test add, remove and change status of PolicyPool components", function
 
     // When suspended, withdrawals are not allowed
     await expect(pool.connect(lp).withdraw(etk, _A(100))).to.be.revertedWith(
-      "eToken not found or withdraws not allowed"
+      "Component must be active or deprecated"
     );
 
     // Only LEVEL1 can reactivate
@@ -126,7 +128,9 @@ describe("Test add, remove and change status of PolicyPool components", function
     await expect(pool.connect(level1).removeComponent(etk)).not.to.be.reverted;
     expect(await pool.getComponentStatus(etk)).to.be.equal(ST_INACTIVE);
 
-    await expect(pool.connect(lp).deposit(etk, _A(200))).to.be.revertedWith("Component is not an eToken");
+    await expect(pool.connect(lp).deposit(etk, _A(200))).to.be.revertedWith(
+      "Component is not of the right kind"
+    );
   });
 
   it("Change status and remove RiskModule", async function () {
@@ -144,9 +148,10 @@ describe("Test add, remove and change status of PolicyPool components", function
     expect(await pool.getComponentStatus(rm)).to.be.equal(ST_DEPRECATED);
 
     // When deprecated can't create policy
-    await expect(rm.connect(cust).newPolicy(_A(36), _A(1), _W(1 / 37), start + 3600, cust, 2)).to.be.revertedWith(
-      "RM module not found or not active"
-    );
+      rm.connect(cust).newPolicy(_A(36), _A(1), _W(1 / 37), start + 3600, cust, 2)
+    await expect(
+      rm.connect(cust).newPolicy(_A(36), _A(1), _W(1 / 37), start + 3600, cust, 2)
+    ).to.be.revertedWith("Component not found or not active");
 
     // But policies can be resolved
     await expect(rm.connect(cust).resolvePolicy([...policy], _A(10))).not.to.be.reverted;
@@ -166,12 +171,12 @@ describe("Test add, remove and change status of PolicyPool components", function
     expect(await pool.getComponentStatus(rm)).to.be.equal(ST_SUSPENDED);
 
     // When suspended, policy creation / resolutions are not allowed
-    await expect(rm.connect(cust).resolvePolicy([...policy], _A(10))).to.be.revertedWith(
-      "Module must be active or deprecated to process resolutions"
+    await expect(rm.connect(cust).resolvePolicy(policy, _A(10))).to.be.revertedWith(
+      "Component must be active or deprecated"
     );
-    await expect(rm.connect(cust).newPolicy(_A(36), _A(1), _W(1 / 37), start + 3600, cust, 4)).to.be.revertedWith(
-      "RM module not found or not active"
-    );
+    await expect(
+      rm.connect(cust).newPolicy(_A(36), _A(1), _W(1 / 37), start + 3600, cust, 4)
+    ).to.be.revertedWith("Component not found or not active");
 
     // Can't be removed if not deprecated before, or if has active policies
     await expect(pool.connect(level1).removeComponent(rm)).to.be.revertedWith("Component not deprecated");
@@ -185,9 +190,9 @@ describe("Test add, remove and change status of PolicyPool components", function
     await expect(pool.connect(level1).removeComponent(rm)).not.to.be.reverted;
     expect(await pool.getComponentStatus(rm)).to.be.equal(ST_INACTIVE);
 
-    await expect(rm.connect(cust).newPolicy(_A(36), _A(1), _W(1 / 37), start + 3600, cust, 5)).to.be.revertedWith(
-      "Component is not a RiskModule"
-    );
+    await expect(
+      rm.connect(cust).newPolicy(_A(36), _A(1), _W(1 / 37), start + 3600, cust, 5)
+    ).to.be.revertedWith("Component is not of the right kind");
   });
 
   it("Change status and remove PremiumsAccount", async function () {
@@ -205,9 +210,9 @@ describe("Test add, remove and change status of PolicyPool components", function
     expect(await pool.getComponentStatus(premiumsAccount)).to.be.equal(ST_DEPRECATED);
 
     // When deprecated can't create policy
-    await expect(rm.connect(cust).newPolicy(_A(36), _A(1), _W(1 / 37), start + 3600, cust, 2)).to.be.revertedWith(
-      "PremiumsAccount not found or not active"
-    );
+    await expect(
+      rm.connect(cust).newPolicy(_A(36), _A(1), _W(1 / 37), start + 3600, cust, 2)
+    ).to.be.revertedWith("Component not found or not active");
 
     // But policies can be resolved
     await expect(rm.connect(cust).resolvePolicy([...policy], _A(10))).not.to.be.reverted;
@@ -224,12 +229,12 @@ describe("Test add, remove and change status of PolicyPool components", function
     expect(await pool.getComponentStatus(premiumsAccount)).to.be.equal(ST_SUSPENDED);
 
     // When suspended, policy creation / resolutions are not allowed
-    await expect(rm.connect(cust).resolvePolicy([...policy], _A(10))).to.be.revertedWith(
-      "PremiumsAccount must be active or deprecated to process resolutions"
+    await expect(rm.connect(cust).resolvePolicy(policy, _A(10))).to.be.revertedWith(
+      "Component must be active or deprecated"
     );
-    await expect(rm.connect(cust).newPolicy(_A(36), _A(1), _W(1 / 37), start + 3600, cust, 4)).to.be.revertedWith(
-      "PremiumsAccount not found or not active"
-    );
+    await expect(
+      rm.connect(cust).newPolicy(_A(36), _A(1), _W(1 / 37), start + 3600, cust, 4)
+    ).to.be.revertedWith("Component not found or not active");
 
     // Can't be removed if not deprecated before, or if has active policies
     await expect(pool.connect(level1).removeComponent(premiumsAccount)).to.be.revertedWith("Component not deprecated");
@@ -250,8 +255,8 @@ describe("Test add, remove and change status of PolicyPool components", function
     expect(borrowerRemovedEvt.args.defaultedDebt).to.be.equal(internalLoan);
     expect(await pool.getComponentStatus(premiumsAccount)).to.be.equal(ST_INACTIVE);
 
-    await expect(rm.connect(cust).newPolicy(_A(36), _A(1), _W(1 / 37), start + 3600, cust, 5)).to.be.revertedWith(
-      "Component is not a PremiumsAccount"
-    );
+    await expect(
+      rm.connect(cust).newPolicy(_A(36), _A(1), _W(1 / 37), start + 3600, cust, 5)
+    ).to.be.revertedWith("Component is not of the right kind");
   });
 });

--- a/test/test-policy-pool.js
+++ b/test/test-policy-pool.js
@@ -354,6 +354,18 @@ describe("PolicyPool contract", function () {
     );
   });
 
+  it("Must revert if new policy values must be greater or equal than old policy", async () => {
+    const { rm, pool } = await helpers.loadFixture(deployRmWithPolicyFixture);
+
+    const now = await helpers.time.latest();
+    const p1 = await createNewPolicy(rm, backend, pool, _A(1000), _A(10), _W(0), now + 3600 * 5, cust, cust, 222);
+    let p2 = [...p1];
+    p2[1] -= _A(1); // change new policy payout
+    await expect(rm.connect(backend).replacePolicyRaw([...p1], [...p2], backend, 1234)).to.be.revertedWith(
+      "New policy must be greater or equal than old policy"
+    );
+  });
+
   it("Must revert if new policy have different start date", async () => {
     const { rm, pool, policy } = await helpers.loadFixture(deployRmWithPolicyFixture);
 

--- a/test/test-policy-pool.js
+++ b/test/test-policy-pool.js
@@ -333,6 +333,14 @@ describe("PolicyPool contract", function () {
     ).to.be.revertedWith("Old policy is expired");
   });
 
+  it("Only PolicyPool can call PA policyReplaced", async () => {
+    const { pool, policy } = await helpers.loadFixture(deployRmWithPolicyFixture);
+
+    const etk = await createEToken(pool, {});
+    const pa = await deployPremiumsAccount(pool, { srEtk: etk });
+    await expect(pa.policyReplaced([...policy], [...policy])).to.be.revertedWith("The caller must be the PolicyPool");
+  });
+
   it("Replacement policy must have a new unique internalId", async () => {
     const { policy, rm } = await helpers.loadFixture(deployRmWithPolicyFixture);
     await expect(

--- a/test/test-policy-pool.js
+++ b/test/test-policy-pool.js
@@ -11,7 +11,7 @@ const {
 } = require("../js/test-utils");
 const hre = require("hardhat");
 const helpers = require("@nomicfoundation/hardhat-network-helpers");
-const { ComponentStatus, RiskModuleParameter } = require("../js/enums.js");
+const { ComponentStatus } = require("../js/enums.js");
 const { ZeroAddress } = hre.ethers;
 
 describe("PolicyPool contract", function () {
@@ -304,69 +304,6 @@ describe("PolicyPool contract", function () {
     await expect(pool.replacePolicy([...policy], [...policy], ZeroAddress, 1234)).to.be.revertedWith(
       "Pausable: paused"
     );
-  });
-
-  it("Reverts if new policy is lower than previous", async () => {
-    const { policy, rm } = await helpers.loadFixture(deployRmWithPolicyFixture);
-
-    // Old Policy: { payout= 1000, premium = 10, expiration= now + 3600 + 5}
-    await expect(
-      rm.connect(backend).replacePolicy([...policy], _A(999), policy.premium, policy.lossProb, policy.expiration, 1234)
-    ).to.be.revertedWith("Policy replacement must be greater or equal than old policy");
-
-    await expect(
-      rm.connect(backend).replacePolicy([...policy], policy.payout, _A(9), policy.lossProb, policy.expiration, 1234)
-    ).to.be.revertedWith("Policy replacement must be greater or equal than old policy");
-
-    const now = await helpers.time.latest();
-    await expect(
-      rm.connect(backend).replacePolicy([...policy], policy.payout, policy.premium, policy.lossProb, now + 3600, 1234)
-    ).to.be.revertedWith("Policy replacement must be greater or equal than old policy");
-  });
-
-  it("It reverts if the premium >= payout", async () => {
-    const { policy, rm } = await helpers.loadFixture(deployRmWithPolicyFixture);
-
-    await expect(
-      rm.connect(backend).replacePolicy([...policy], _A(100), _A(101), policy.lossProb, policy.expiration, 1234)
-    ).to.be.revertedWith("Premium must be less than payout");
-  });
-
-  it("It reverts if new policy exceeds max duration", async () => {
-    const { policy, rm } = await helpers.loadFixture(deployRmWithPolicyFixture);
-    const now = await helpers.time.latest();
-    // Max Duration = 8760
-    const newExp = 8760 * 3600 + now + 1000;
-    await expect(
-      rm.connect(backend).replacePolicy([...policy], policy.payout, policy.premium, policy.lossProb, newExp, 1234)
-    ).to.be.revertedWith("Policy exceeds max duration");
-  });
-
-  it("It reverts if new payout > maxPayoutPerPolicy", async () => {
-    const { policy, rm } = await helpers.loadFixture(deployRmWithPolicyFixture);
-
-    const newPayout = (await rm.maxPayoutPerPolicy()) + 1n;
-    await expect(
-      rm
-        .connect(backend)
-        .replacePolicy([...policy], newPayout, policy.premium, policy.lossProb, policy.expiration, 1234)
-    ).to.be.revertedWith("RiskModule: Payout is more than maximum per policy");
-  });
-
-  it("It reverts if _activeExposure > exposureLimit", async () => {
-    const { policy, rm } = await helpers.loadFixture(deployRmWithPolicyFixture);
-
-    expect(await rm.exposureLimit()).to.be.equal(_A(1000000));
-    // Set exposureLimit to 1500 and maxPayoutPerPolicy to allow bigger policies
-    await rm.setParam(RiskModuleParameter.maxPayoutPerPolicy, _A(3000));
-    await rm.setParam(RiskModuleParameter.exposureLimit, _A(1100));
-    expect(await rm.exposureLimit()).to.be.equal(_A(1100));
-
-    await expect(
-      rm
-        .connect(backend)
-        .replacePolicy([...policy], policy.payout + _A(200), policy.premium, policy.lossProb, policy.expiration, 1234)
-    ).to.be.revertedWith("RiskModule: Exposure limit exceeded");
   });
 
   it("Components must be active to replace policies", async () => {

--- a/test/test-policy-pool.js
+++ b/test/test-policy-pool.js
@@ -116,9 +116,7 @@ describe("PolicyPool contract", function () {
     const etk = await addEToken(pool, {});
     const premiumsAccount = await deployPremiumsAccount(pool, { jrEtk: etk }, false);
 
-    await expect(pool.addComponent(premiumsAccount, 3))
-      .to.emit(etk, "InternalBorrowerAdded")
-      .withArgs(premiumsAccount);
+    await expect(pool.addComponent(premiumsAccount, 3)).to.emit(etk, "InternalBorrowerAdded").withArgs(premiumsAccount);
   });
 
   it("Removes the PA as borrower from the jr etoken on PremiumsAccount removal", async () => {
@@ -140,9 +138,7 @@ describe("PolicyPool contract", function () {
     const etk = await addEToken(pool, {});
     const premiumsAccount = await deployPremiumsAccount(pool, { srEtk: etk }, false);
 
-    await expect(pool.addComponent(premiumsAccount, 3))
-      .to.emit(etk, "InternalBorrowerAdded")
-      .withArgs(premiumsAccount);
+    await expect(pool.addComponent(premiumsAccount, 3)).to.emit(etk, "InternalBorrowerAdded").withArgs(premiumsAccount);
   });
 
   it("Removes the PA as borrower from the sr etoken on PremiumsAccount removal", async () => {
@@ -287,7 +283,9 @@ describe("PolicyPool contract", function () {
     const { policy, rm, pool } = await helpers.loadFixture(deployRmWithPolicyFixture);
     await expect(rm.connect(backend).resolvePolicy([...policy], policy.payout)).not.to.be.reverted;
     expect(await pool.isActive(policy.id)).to.be.false;
-    await expect(pool.replacePolicy([...policy], [...policy], ZeroAddress, 1234)).to.be.revertedWith("Policy not found");
+    await expect(pool.replacePolicy([...policy], [...policy], ZeroAddress, 1234)).to.be.revertedWith(
+      "Policy not found"
+    );
   });
 
   it("Only RM can replace policies", async () => {
@@ -301,12 +299,16 @@ describe("PolicyPool contract", function () {
     const { policy, pool, rm, premiumsAccount } = await helpers.loadFixture(deployRmWithPolicyFixture);
     await pool.changeComponentStatus(premiumsAccount, ComponentStatus.deprecated);
     await expect(
-      rm.connect(backend).replacePolicy([...policy], policy.payout, policy.premium, policy.lossProb, policy.expiration, 1234)
+      rm
+        .connect(backend)
+        .replacePolicy([...policy], policy.payout, policy.premium, policy.lossProb, policy.expiration, 1234)
     ).to.be.revertedWith("Component not found or not active");
     await pool.changeComponentStatus(premiumsAccount, ComponentStatus.active);
     await pool.changeComponentStatus(rm, ComponentStatus.deprecated);
     await expect(
-      rm.connect(backend).replacePolicy([...policy], policy.payout, policy.premium, policy.lossProb, policy.expiration, 1234)
+      rm
+        .connect(backend)
+        .replacePolicy([...policy], policy.payout, policy.premium, policy.lossProb, policy.expiration, 1234)
     ).to.be.revertedWith("Component not found or not active");
   });
 
@@ -314,14 +316,18 @@ describe("PolicyPool contract", function () {
     const { policy, rm } = await helpers.loadFixture(deployRmWithPolicyFixture);
     await helpers.time.increaseTo(policy.expiration + 100n);
     await expect(
-      rm.connect(backend).replacePolicy([...policy], policy.payout, policy.premium, policy.lossProb, policy.expiration, 1234)
+      rm
+        .connect(backend)
+        .replacePolicy([...policy], policy.payout, policy.premium, policy.lossProb, policy.expiration, 1234)
     ).to.be.revertedWith("Old policy is expired");
   });
 
   it("Replacement policy must have a new unique internalId", async () => {
     const { policy, rm } = await helpers.loadFixture(deployRmWithPolicyFixture);
     await expect(
-      rm.connect(backend).replacePolicy([...policy], policy.payout, policy.premium, policy.lossProb, policy.expiration, 123)
+      rm
+        .connect(backend)
+        .replacePolicy([...policy], policy.payout, policy.premium, policy.lossProb, policy.expiration, 123)
     ).to.be.revertedWith("Policy already exists");
   });
 

--- a/test/test-policy-pool.js
+++ b/test/test-policy-pool.js
@@ -279,6 +279,15 @@ describe("PolicyPool contract", function () {
     );
   });
 
+  it("Can't expire policies when the pool is paused", async () => {
+    const { accessManager, policy, pool } = await helpers.loadFixture(deployRmWithPolicyFixture);
+
+    await grantRole(hre, accessManager, "GUARDIAN_ROLE", owner);
+    await expect(pool.connect(owner).pause()).to.emit(pool, "Paused");
+
+    await expect(pool.connect(backend).expirePolicies([[...policy]])).to.be.revertedWith("Pausable: paused");
+  });
+
   it("Can't replace resolved policies", async () => {
     const { policy, rm, pool } = await helpers.loadFixture(deployRmWithPolicyFixture);
     await expect(rm.connect(backend).resolvePolicy([...policy], policy.payout)).not.to.be.reverted;

--- a/test/test-risk-module.js
+++ b/test/test-risk-module.js
@@ -271,7 +271,9 @@ describe("RiskModule contract", function () {
       rm
         .connect(backend)
         .replacePolicy([...policy], policy.payout, policy.premium, policy.lossProb, policy.expiration, 1234)
-    ).to.emit(pool, "PolicyReplaced");
+    )
+      .to.emit(pool, "NewPolicy")
+      .to.emit(pool, "PolicyReplaced");
   });
 
   async function makePolicy({ payout, premium, lossProbability, expiration, payer, onBehalfOf, internalId }) {

--- a/test/test-risk-module.js
+++ b/test/test-risk-module.js
@@ -264,6 +264,16 @@ describe("RiskModule contract", function () {
     ).to.be.revertedWith("Pausable: paused");
   });
 
+  it("Should emit PolicyReplaced when policy is repla", async () => {
+    const { policy, rm, pool } = await helpers.loadFixture(deployRmWithPolicyFixture);
+
+    await expect(
+      rm
+        .connect(backend)
+        .replacePolicy([...policy], policy.payout, policy.premium, policy.lossProb, policy.expiration, 1234)
+    ).to.emit(pool, "PolicyReplaced");
+  });
+
   async function makePolicy({ payout, premium, lossProbability, expiration, payer, onBehalfOf, internalId }) {
     const now = await helpers.time.latest();
     const policy = {

--- a/test/test-risk-module.js
+++ b/test/test-risk-module.js
@@ -264,7 +264,7 @@ describe("RiskModule contract", function () {
     ).to.be.revertedWith("Pausable: paused");
   });
 
-  it("Should emit PolicyReplaced when policy is repla", async () => {
+  it("Should emit PolicyReplaced when policy is replaced", async () => {
     const { policy, rm, pool } = await helpers.loadFixture(deployRmWithPolicyFixture);
 
     await expect(

--- a/test/test-risk-module.js
+++ b/test/test-risk-module.js
@@ -1,8 +1,9 @@
 const { expect } = require("chai");
-const { grantRole, amountFunction, _W } = require("../js/utils");
-const { initCurrency, deployPool, deployPremiumsAccount, addRiskModule, addEToken } = require("../js/test-utils");
 const { ethers } = require("hardhat");
+const { RiskModuleParameter } = require("../js/enums");
 const helpers = require("@nomicfoundation/hardhat-network-helpers");
+const { grantRole, amountFunction, _W, getTransactionEvent } = require("../js/utils");
+const { initCurrency, deployPool, deployPremiumsAccount, addRiskModule, addEToken } = require("../js/test-utils");
 
 // NOTICE: This tests only cover the bits not already covered by the python tests in the `tests`
 // directory.
@@ -11,51 +12,84 @@ const helpers = require("@nomicfoundation/hardhat-network-helpers");
 // here through a mock contract.
 
 describe("RiskModule contract", function () {
-  let currency;
-  let pool;
-  let accessManager;
-  let premiumsAccount;
   let _A;
-  let backend, cust, lp;
-  let RiskModule;
-  let rm;
+  let backend, cust, lp, owner;
 
   beforeEach(async () => {
-    [, lp, cust, backend] = await ethers.getSigners();
+    [, lp, cust, backend, owner] = await ethers.getSigners();
 
     _A = amountFunction(6);
+  });
 
-    currency = await initCurrency(
+  async function deployPoolFixture() {
+    const currency = await initCurrency(
       { name: "Test USDC", symbol: "USDC", decimals: 6, initial_supply: _A(10000) },
       [lp, cust, backend],
       [_A(5000), _A(500), _A(1000)]
     );
 
-    pool = await deployPool({
+    const pool = await deployPool({
       currency: currency,
       grantRoles: ["LEVEL1_ROLE", "LEVEL2_ROLE"],
       treasuryAddress: "0x8626f6940E2eb28930eFb4CeF49B2d1F2C9C1199", // Random address
     });
     pool._A = _A;
 
+    const accessManager = await hre.ethers.getContractAt("AccessManager", await pool.access());
+    return { pool, accessManager, currency };
+  }
+
+  async function deployRiskModuleFixture() {
+    const { pool, accessManager, currency } = await helpers.loadFixture(deployPoolFixture);
+    // Setup the liquidity sources
     const etk = await addEToken(pool, {});
-
-    premiumsAccount = await deployPremiumsAccount(pool, { srEtk: etk });
-
-    accessManager = await ethers.getContractAt("AccessManager", await pool.access());
-
-    RiskModule = await ethers.getContractFactory("RiskModuleMock");
+    const premiumsAccount = await deployPremiumsAccount(pool, { srEtk: etk });
 
     await currency.connect(lp).approve(pool, _A(5000));
     await pool.connect(lp).deposit(etk, _A(5000));
 
-    rm = await addRiskModule(pool, premiumsAccount, RiskModule, {
+    // Setup the risk module
+    const RiskModule = await hre.ethers.getContractFactory("RiskModuleMock");
+    const rm = await addRiskModule(pool, premiumsAccount, RiskModule, {
       extraArgs: [],
     });
+
     await accessManager.grantComponentRole(rm, await rm.PRICER_ROLE(), backend);
-  });
+    await accessManager.grantComponentRole(rm, await rm.RESOLVER_ROLE(), backend);
+    await accessManager.grantComponentRole(rm, await rm.REPLACER_ROLE(), backend);
+
+    return { etk, premiumsAccount, rm, RiskModule, pool, accessManager, currency };
+  }
+
+  async function deployRmWithPolicyFixture() {
+    const { rm, pool, currency, accessManager, premiumsAccount } = await helpers.loadFixture(deployRiskModuleFixture);
+    const now = await helpers.time.latest();
+
+    // Deploy a new policy
+    await currency.connect(cust).approve(pool, _A(110));
+    await currency.connect(cust).approve(backend, _A(110));
+
+    const tx = await rm.connect(backend).newPolicy(
+      _A(1000), // payout
+      _A(10), // premium
+      _W(0), // lossProb
+      now + 3600 * 5, // expiration
+      cust, // payer
+      cust, // holder
+      123 // internalId
+    );
+
+    const receipt = await tx.wait();
+
+    // Try to resolve it without going through the riskModule
+    const newPolicyEvt = getTransactionEvent(pool.interface, receipt, "NewPolicy");
+
+    return { policy: newPolicyEvt.args.policy, receipt, rm, currency, accessManager, pool, premiumsAccount };
+  }
 
   it("Set params jrCollRatio validations", async () => {
+    const { rm, accessManager } = await helpers.loadFixture(deployRiskModuleFixture);
+
     let jrCollRatio = 0;
     await rm.setParam(1, jrCollRatio);
 
@@ -67,6 +101,7 @@ describe("RiskModule contract", function () {
   });
 
   it("Allows msg.sender as payer", async () => {
+    const { pool, rm, currency } = await helpers.loadFixture(deployRiskModuleFixture);
     await currency.connect(backend).approve(pool, _A(110));
 
     const policy = await makePolicy({ payer: backend });
@@ -78,6 +113,8 @@ describe("RiskModule contract", function () {
   });
 
   it("Doesn't allow another payer by default", async () => {
+    const { pool, rm, currency } = await helpers.loadFixture(deployRiskModuleFixture);
+
     // The customer approved the spending for the pool
     await currency.connect(cust).approve(pool, _A(110));
 
@@ -91,6 +128,8 @@ describe("RiskModule contract", function () {
   });
 
   it("Allows another payer given the right allowances", async () => {
+    const { pool, rm, currency } = await helpers.loadFixture(deployRiskModuleFixture);
+
     // The customer approved the spending for the pool
     await currency.connect(cust).approve(pool, _A(110));
 
@@ -106,6 +145,8 @@ describe("RiskModule contract", function () {
   });
 
   it("Does not allow an exposure limit of zero", async () => {
+    const { pool, premiumsAccount, RiskModule } = await helpers.loadFixture(deployRiskModuleFixture);
+
     await expect(
       addRiskModule(pool, premiumsAccount, RiskModule, {
         exposureLimit: 0,
@@ -115,6 +156,7 @@ describe("RiskModule contract", function () {
   });
 
   it("Does not allow wallet with zero address", async () => {
+    const { pool, premiumsAccount, RiskModule } = await helpers.loadFixture(deployRiskModuleFixture);
     await expect(
       addRiskModule(pool, premiumsAccount, RiskModule, {
         wallet: hre.ethers.ZeroAddress,
@@ -124,12 +166,89 @@ describe("RiskModule contract", function () {
   });
 
   it("Does not allow a maxpayout of zero", async () => {
+    const { pool, premiumsAccount, RiskModule } = await helpers.loadFixture(deployRiskModuleFixture);
     await expect(
       addRiskModule(pool, premiumsAccount, RiskModule, {
         maxPayoutPerPolicy: 0,
         extraArgs: [],
       })
     ).to.be.revertedWith("Exposure and MaxPayout must be >0");
+  });
+
+  it("Reverts if new policy is lower than previous", async () => {
+    const { policy, rm } = await helpers.loadFixture(deployRmWithPolicyFixture);
+
+    // Old Policy: { payout= 1000, premium = 10, expiration= now + 3600 + 5}
+    await expect(
+      rm.connect(backend).replacePolicy([...policy], _A(999), policy.premium, policy.lossProb, policy.expiration, 1234)
+    ).to.be.revertedWith("Policy replacement must be greater or equal than old policy");
+
+    await expect(
+      rm.connect(backend).replacePolicy([...policy], policy.payout, _A(9), policy.lossProb, policy.expiration, 1234)
+    ).to.be.revertedWith("Policy replacement must be greater or equal than old policy");
+
+    const now = await helpers.time.latest();
+    await expect(
+      rm.connect(backend).replacePolicy([...policy], policy.payout, policy.premium, policy.lossProb, now + 3600, 1234)
+    ).to.be.revertedWith("Policy replacement must be greater or equal than old policy");
+  });
+
+  it("It reverts if the premium >= payout", async () => {
+    const { policy, rm } = await helpers.loadFixture(deployRmWithPolicyFixture);
+
+    await expect(
+      rm.connect(backend).replacePolicy([...policy], _A(100), _A(101), policy.lossProb, policy.expiration, 1234)
+    ).to.be.revertedWith("Premium must be less than payout");
+  });
+
+  it("It reverts if new policy exceeds max duration", async () => {
+    const { policy, rm } = await helpers.loadFixture(deployRmWithPolicyFixture);
+    const now = await helpers.time.latest();
+    // Max Duration = 8760
+    const newExp = 8760 * 3600 + now + 1000;
+    await expect(
+      rm.connect(backend).replacePolicy([...policy], policy.payout, policy.premium, policy.lossProb, newExp, 1234)
+    ).to.be.revertedWith("Policy exceeds max duration");
+  });
+
+  it("It reverts if new payout > maxPayoutPerPolicy", async () => {
+    const { policy, rm } = await helpers.loadFixture(deployRmWithPolicyFixture);
+
+    const newPayout = (await rm.maxPayoutPerPolicy()) + 1n;
+    await expect(
+      rm
+        .connect(backend)
+        .replacePolicy([...policy], newPayout, policy.premium, policy.lossProb, policy.expiration, 1234)
+    ).to.be.revertedWith("RiskModule: Payout is more than maximum per policy");
+  });
+
+  it("It reverts if _activeExposure > exposureLimit", async () => {
+    const { policy, rm } = await helpers.loadFixture(deployRmWithPolicyFixture);
+
+    expect(await rm.exposureLimit()).to.be.equal(_A(1000000));
+    // Set exposureLimit to 1500 and maxPayoutPerPolicy to allow bigger policies
+    await rm.setParam(RiskModuleParameter.maxPayoutPerPolicy, _A(3000));
+    await rm.setParam(RiskModuleParameter.exposureLimit, _A(1100));
+    expect(await rm.exposureLimit()).to.be.equal(_A(1100));
+
+    await expect(
+      rm
+        .connect(backend)
+        .replacePolicy([...policy], policy.payout + _A(200), policy.premium, policy.lossProb, policy.expiration, 1234)
+    ).to.be.revertedWith("RiskModule: Exposure limit exceeded");
+  });
+
+  it("Rejects replace policy if the RM is paused", async () => {
+    const { policy, rm, accessManager } = await helpers.loadFixture(deployRmWithPolicyFixture);
+
+    await grantRole(hre, accessManager, "GUARDIAN_ROLE", owner);
+    await expect(rm.connect(owner).pause()).to.emit(rm, "Paused");
+
+    await expect(
+      rm
+        .connect(backend)
+        .replacePolicy([...policy], policy.payout, policy.premium, policy.lossProb, policy.expiration, 1234)
+    ).to.be.revertedWith("Pausable: paused");
   });
 
   async function makePolicy({ payout, premium, lossProbability, expiration, payer, onBehalfOf, internalId }) {

--- a/test/test-risk-module.js
+++ b/test/test-risk-module.js
@@ -273,7 +273,8 @@ describe("RiskModule contract", function () {
         .replacePolicy([...policy], policy.payout, policy.premium, policy.lossProb, policy.expiration, 1234)
     )
       .to.emit(pool, "NewPolicy")
-      .to.emit(pool, "PolicyReplaced");
+      .to.emit(pool, "PolicyReplaced")
+      .withArgs(rm, policy.id, policy.id - 123n + 1234n);
   });
 
   async function makePolicy({ payout, premium, lossProbability, expiration, payer, onBehalfOf, internalId }) {

--- a/test/test-supports-interface.js
+++ b/test/test-supports-interface.js
@@ -51,10 +51,12 @@ describe("Supports interface implementation", function () {
       IERC721: "0x80ac58cd",
       IAccessControl: "0x7965db0b",
       IEToken: "0x90770621",
-      IPolicyPool: "0x3234fad6",
+      // IPolicyPool: "0x3234fad6", - Up to v2.7
+      IPolicyPool: "0x0ce33b78",
       IPolicyPoolComponent: "0x4d15eb03",
       IRiskModule: "0xda40804f",
-      IPremiumsAccount: "0xb76712ec",
+      // IPremiumsAccount: "0xb76712ec", - Up to v2.7
+      IPremiumsAccount: "0x1ce4a652",
       ILPWhitelist: "0xf8722d89",
       IAccessManager: "0x272b8c47",
       IAssetManager: "0x799c2a5c",

--- a/test/test-supports-interface.js
+++ b/test/test-supports-interface.js
@@ -36,6 +36,7 @@ describe("Supports interface implementation", function () {
       "ILPWhitelist",
       "IAccessManager",
       "IAssetManager",
+      "IPolicyHolder",
     ];
     const iinterfaceIds = {};
     for (const iName of iinterfaces) {
@@ -57,6 +58,7 @@ describe("Supports interface implementation", function () {
       ILPWhitelist: "0xf8722d89",
       IAccessManager: "0x272b8c47",
       IAssetManager: "0x799c2a5c",
+      IPolicyHolder: "0x3ece0a89",
     };
 
     const _A = amountFunction(6);

--- a/test/test-tiered-signed-riskmodule.js
+++ b/test/test-tiered-signed-riskmodule.js
@@ -108,9 +108,7 @@ describe("TieredSignedQuoteRiskModule contract tests", function () {
     await expect(rm.connect(level1).pushBucket(_W("0.15"), defaultBucketParams({}))).to.be.revertedWith(
       accessControlMessage(level1, rm, "LEVEL2_ROLE")
     );
-    await expect(rm.connect(level1).resetBuckets()).to.be.revertedWith(
-      accessControlMessage(level1, rm, "LEVEL2_ROLE")
-    );
+    await expect(rm.connect(level1).resetBuckets()).to.be.revertedWith(accessControlMessage(level1, rm, "LEVEL2_ROLE"));
     await grantRole(hre, accessManager, "LEVEL1_ROLE", level1);
     await expect(rm.connect(level1).pushBucket(_W("0.15"), defaultBucketParams({}))).not.to.be.reverted;
     await expect(rm.connect(level1).resetBuckets()).not.to.be.reverted;
@@ -119,9 +117,7 @@ describe("TieredSignedQuoteRiskModule contract tests", function () {
     await expect(rm.connect(level2).pushBucket(_W("0.15"), defaultBucketParams({}))).to.be.revertedWith(
       accessControlMessage(level2, rm, "LEVEL2_ROLE")
     );
-    await expect(rm.connect(level2).resetBuckets()).to.be.revertedWith(
-      accessControlMessage(level2, rm, "LEVEL2_ROLE")
-    );
+    await expect(rm.connect(level2).resetBuckets()).to.be.revertedWith(accessControlMessage(level2, rm, "LEVEL2_ROLE"));
     await grantRole(hre, accessManager, "LEVEL2_ROLE", level2);
     await expect(rm.connect(level2).pushBucket(_W("0.15"), defaultBucketParams({}))).not.to.be.reverted;
     await expect(rm.connect(level2).resetBuckets()).not.to.be.reverted;
@@ -222,7 +218,7 @@ describe("TieredSignedQuoteRiskModule contract tests", function () {
       .withArgs(_W("0.15"), bucket15.asParams());
 
     // Policy with lossProb < 10 uses bucket10
-    const policy1Params = await defaultPolicyParams({ rm: rm,  lossProb: _W("0.055"), payout: _A("790") });
+    const policy1Params = await defaultPolicyParams({ rm: rm, lossProb: _W("0.055"), payout: _A("790") });
 
     const signature1 = await makeSignedQuote(signer, policy1Params);
     const policy1Tx = await newPolicy(rm, cust, policy1Params, cust, signature1);

--- a/tests/test_policypool.py
+++ b/tests/test_policypool.py
@@ -1975,12 +1975,12 @@ def test_replace_policy(tenv):
         rm.replace_policy(**replace_kwargs)
 
     pool.currency.approve("owner", pool.contract_id, _W(90))
-    balance_before = {}
-    balance_before["JR"] = pool.currency.balance_of(etkJR)
-    balance_before["SR"] = pool.currency.balance_of(etkSR)
-    balance_before["PA"] = pool.currency.balance_of(premiums_account)
-    balance_before["ENS"] = pool.currency.balance_of("ENS")
-    print(balance_before)
+    balance_before = {
+        "JR": pool.currency.balance_of(etkJR),
+        "SR": pool.currency.balance_of(etkSR),
+        "PA": pool.currency.balance_of(premiums_account),
+        "ENS": pool.currency.balance_of("ENS"),
+    }
 
     new_policy = rm.replace_policy(**replace_kwargs)
     rm.active_exposure.assert_equal(_W(4200))
@@ -2090,13 +2090,12 @@ def test_replace_policy_two_times(tenv):
     )
 
     pool.access.grant_component_role(rm, "REPLACER_ROLE", "owner")
-
-    balance_before = {}
-    balance_before["JR"] = USD.balance_of(etkJR)
-    balance_before["SR"] = USD.balance_of(etkSR)
-    balance_before["PA"] = USD.balance_of(premiums_account)
-    balance_before["ENS"] = USD.balance_of("ENS")
-    print(balance_before)
+    balance_before = {
+        "JR": USD.balance_of(etkJR),
+        "SR": USD.balance_of(etkSR),
+        "PA": USD.balance_of(premiums_account),
+        "ENS": USD.balance_of("ENS"),
+    }
 
     new_policy = rm.replace_policy(**replace_kwargs)
     rm.active_exposure.assert_equal(_W(4200))
@@ -2130,12 +2129,12 @@ def test_replace_policy_two_times(tenv):
         internal_id=124,
     )
 
-    balance_before = {}
-    balance_before["JR"] = USD.balance_of(etkJR)
-    balance_before["SR"] = USD.balance_of(etkSR)
-    balance_before["PA"] = USD.balance_of(premiums_account)
-    balance_before["ENS"] = USD.balance_of("ENS")
-    print(balance_before)
+    balance_before = {
+        "JR": USD.balance_of(etkJR),
+        "SR": USD.balance_of(etkSR),
+        "PA": USD.balance_of(premiums_account),
+        "ENS": USD.balance_of("ENS"),
+    }
 
     third_policy = rm.replace_policy(**replace_kwargs)
     rm.active_exposure.assert_equal(_W(4200))
@@ -2239,13 +2238,12 @@ def test_replace_policy_same_params(tenv):
     )
 
     pool.access.grant_component_role(rm, "REPLACER_ROLE", "owner")
-
-    balance_before = {}
-    balance_before["JR"] = USD.balance_of(etkJR)
-    balance_before["SR"] = USD.balance_of(etkSR)
-    balance_before["PA"] = USD.balance_of(premiums_account)
-    balance_before["ENS"] = USD.balance_of("ENS")
-    print(balance_before)
+    balance_before = {
+        "JR": USD.balance_of(etkJR),
+        "SR": USD.balance_of(etkSR),
+        "PA": USD.balance_of(premiums_account),
+        "ENS": USD.balance_of("ENS"),
+    }
 
     new_policy = rm.replace_policy(**replace_kwargs)
     rm.active_exposure.assert_equal(_W(2100))
@@ -2430,12 +2428,11 @@ def test_replace_policy_zero_sr_scr(tenv):
     )
 
     pool.access.grant_component_role(rm, "REPLACER_ROLE", "owner")
-
-    balance_before = {}
-    balance_before["SR"] = USD.balance_of(etkSR)
-    balance_before["PA"] = USD.balance_of(premiums_account)
-    balance_before["ENS"] = USD.balance_of("ENS")
-    print(balance_before)
+    balance_before = {
+        "SR": USD.balance_of(etkSR),
+        "PA": USD.balance_of(premiums_account),
+        "ENS": USD.balance_of("ENS"),
+    }
 
     new_policy = rm.replace_policy(**replace_kwargs)
     rm.active_exposure.assert_equal(new_policy.payout)

--- a/tests/test_policypool.py
+++ b/tests/test_policypool.py
@@ -1956,7 +1956,6 @@ def test_replace_policy(tenv):
 
     timecontrol.fast_forward(4 * DAY)
 
-    pool.currency.approve("owner", pool.contract_id, _W(90))
     replace_kwargs = dict(
         old_policy=policy,
         payout=_W(4200),
@@ -1972,6 +1971,10 @@ def test_replace_policy(tenv):
 
     pool.access.grant_component_role(rm, "REPLACER_ROLE", "owner")
 
+    with pytest.raises(RevertError, match="You must allow ENSURO"):
+        rm.replace_policy(**replace_kwargs)
+
+    pool.currency.approve("owner", pool.contract_id, _W(90))
     balance_before = {}
     balance_before["JR"] = pool.currency.balance_of(etkJR)
     balance_before["SR"] = pool.currency.balance_of(etkSR)

--- a/tests/test_policypool.py
+++ b/tests/test_policypool.py
@@ -2007,6 +2007,272 @@ def test_replace_policy(tenv):
     return locals()
 
 
+def test_replace_policy_two_times(tenv):
+    YAML_SETUP = """
+    risk_modules:
+      - name: CFAR
+        jr_coll_ratio: "0.1"
+        coll_ratio: "0.2"
+        ensuro_pp_fee: "0.05"
+        jr_roc: "0.2"
+        sr_roc: "0.1"
+        wallet: "MGA"
+        roles:
+          - user: owner
+            role: PRICER_ROLE
+          - user: owner
+            role: RESOLVER_ROLE
+    currency:
+        name: USD
+        symbol: $
+        initial_supply: 6000
+        initial_balances:
+        - user: LP1
+          amount: 1000
+        - user: LP2
+          amount: 1000
+        - user: LP3
+          amount: 1000
+        - user: CUST1
+          amount: 200
+        - user: owner
+          amount: 90
+    premiums_accounts:
+    - senior_etk: SR
+      junior_etk: JR
+    etokens:
+      - name: SR
+      - name: JR
+    roles:
+      - user: owner
+        role: LEVEL2_ROLE  # For setting moc
+    """
+
+    pool = load_config(StringIO(YAML_SETUP), tenv.module)
+    timecontrol = tenv.time_control
+    etkSR = pool.etokens["SR"]
+    etkJR = pool.etokens["JR"]
+    USD = pool.currency
+    rm = pool.risk_modules["CFAR"]
+    premiums_account = rm.premiums_account
+
+    with rm.as_(rm.owner):
+        rm.moc = _W("1.1")
+        rm.ensuro_coc_fee = _W("0.05")
+
+    _deposit(pool, "SR", "LP1", _W(1000))
+    _deposit(pool, "JR", "LP2", _W(1000))
+
+    USD.approve("owner", pool.contract_id, _W(200))
+    USD.approve("CUST1", pool.contract_id, _W(100))
+    USD.approve("CUST1", rm.owner, _W(100))
+    policy = rm.new_policy(
+        payout=_W(2100),
+        premium=_W(100),
+        on_behalf_of="CUST1",
+        loss_prob=_W("0.03"),
+        expiration=timecontrol.now + 10 * DAY,
+        internal_id=122,
+    )
+
+    USD.balance_of("CUST1") == _W(100)
+    etkSR.scr.assert_equal(_W("0.1") * _W(2100))
+    etkJR.scr.assert_equal(policy.jr_scr)
+
+    rm.active_exposure.assert_equal(policy.payout)
+    timecontrol.fast_forward(4 * DAY)
+    replace_kwargs = dict(
+        old_policy=policy,
+        payout=_W(4200),
+        premium=_W(190),
+        loss_prob=_W("0.03"),
+        expiration=timecontrol.now + 14 * DAY,
+        payer="owner",
+        internal_id=123,
+    )
+
+    pool.access.grant_component_role(rm, "REPLACER_ROLE", "owner")
+
+    balance_before = {}
+    balance_before["JR"] = USD.balance_of(etkJR)
+    balance_before["SR"] = USD.balance_of(etkSR)
+    balance_before["PA"] = USD.balance_of(premiums_account)
+    balance_before["ENS"] = USD.balance_of("ENS")
+    print(balance_before)
+
+    new_policy = rm.replace_policy(**replace_kwargs)
+    rm.active_exposure.assert_equal(_W(4200))
+    etkSR.scr.assert_equal(_W("0.1") * _W(4200))
+    etkJR.scr.assert_equal(new_policy.jr_scr)
+
+    USD.balance_of(etkJR).assert_equal(balance_before["JR"] + new_policy.jr_coc - policy.jr_coc)
+    USD.balance_of(etkSR).assert_equal(balance_before["SR"] + new_policy.sr_coc - policy.sr_coc)
+    USD.balance_of(premiums_account).assert_equal(
+        balance_before["PA"] + new_policy.pure_premium - policy.pure_premium
+    )
+    USD.balance_of("ENS").assert_equal(
+        balance_before["ENS"] + new_policy.ensuro_commission - policy.ensuro_commission
+    )
+
+    assert pool.owner_of(new_policy.id) == "CUST1"
+
+    # Try to replace the FIRST policy
+    with pytest.raises(RevertError, match="Policy not found"):
+        third_policy = rm.replace_policy(**replace_kwargs)
+
+    # I'll replace the policy again
+    timecontrol.fast_forward(6 * DAY)
+    replace_kwargs = dict(
+        old_policy=new_policy,
+        payout=_W(4200),
+        premium=_W(200),
+        loss_prob=_W("0.03"),
+        expiration=timecontrol.now + 16 * DAY,
+        payer="owner",
+        internal_id=124,
+    )
+
+    balance_before = {}
+    balance_before["JR"] = USD.balance_of(etkJR)
+    balance_before["SR"] = USD.balance_of(etkSR)
+    balance_before["PA"] = USD.balance_of(premiums_account)
+    balance_before["ENS"] = USD.balance_of("ENS")
+    print(balance_before)
+
+    third_policy = rm.replace_policy(**replace_kwargs)
+    rm.active_exposure.assert_equal(_W(4200))
+    etkSR.scr.assert_equal(_W("0.1") * _W(4200))
+    etkJR.scr.assert_equal(third_policy.jr_scr)
+
+    USD.balance_of(etkJR).assert_equal(balance_before["JR"] + third_policy.jr_coc - new_policy.jr_coc)
+    USD.balance_of(etkSR).assert_equal(balance_before["SR"] + third_policy.sr_coc - new_policy.sr_coc)
+    USD.balance_of(premiums_account).assert_equal(
+        balance_before["PA"] + third_policy.pure_premium - new_policy.pure_premium
+    )
+    USD.balance_of("ENS").assert_equal(
+        balance_before["ENS"] + third_policy.ensuro_commission - new_policy.ensuro_commission
+    )
+
+    with pytest.raises(RevertError, match="Policy not found"):
+        rm.resolve_policy(new_policy.id, True)
+
+    assert pool.owner_of(third_policy.id) == "CUST1"
+
+
+def test_replace_policy_same_params(tenv):
+    YAML_SETUP = """
+    risk_modules:
+      - name: CFAR
+        jr_coll_ratio: "0.1"
+        coll_ratio: "0.2"
+        ensuro_pp_fee: "0.05"
+        jr_roc: "0.2"
+        sr_roc: "0.1"
+        wallet: "MGA"
+        roles:
+          - user: owner
+            role: PRICER_ROLE
+          - user: owner
+            role: RESOLVER_ROLE
+    currency:
+        name: USD
+        symbol: $
+        initial_supply: 6000
+        initial_balances:
+        - user: LP1
+          amount: 1000
+        - user: LP2
+          amount: 1000
+        - user: LP3
+          amount: 1000
+        - user: CUST1
+          amount: 200
+        - user: owner
+          amount: 90
+    premiums_accounts:
+    - senior_etk: SR
+      junior_etk: JR
+    etokens:
+      - name: SR
+      - name: JR
+    roles:
+      - user: owner
+        role: LEVEL2_ROLE  # For setting moc
+    """
+
+    pool = load_config(StringIO(YAML_SETUP), tenv.module)
+    timecontrol = tenv.time_control
+    etkSR = pool.etokens["SR"]
+    etkJR = pool.etokens["JR"]
+    USD = pool.currency
+    rm = pool.risk_modules["CFAR"]
+    premiums_account = rm.premiums_account
+
+    with rm.as_(rm.owner):
+        rm.moc = _W("1.1")
+        rm.ensuro_coc_fee = _W("0.05")
+
+    _deposit(pool, "SR", "LP1", _W(1000))
+    _deposit(pool, "JR", "LP2", _W(1000))
+
+    USD.approve("owner", pool.contract_id, _W(90))
+    USD.approve("CUST1", pool.contract_id, _W(100))
+    USD.approve("CUST1", rm.owner, _W(100))
+    policy = rm.new_policy(
+        payout=_W(2100),
+        premium=_W(100),
+        on_behalf_of="CUST1",
+        loss_prob=_W("0.03"),
+        expiration=timecontrol.now + 10 * DAY,
+        internal_id=122,
+    )
+
+    # USD.balance_of("CUST1") == _W(100)
+    etkSR.scr.assert_equal(_W("0.1") * _W(2100))
+    etkJR.scr.assert_equal(policy.jr_scr)
+
+    rm.active_exposure.assert_equal(policy.payout)
+    timecontrol.fast_forward(4 * DAY)
+    replace_kwargs = dict(
+        old_policy=policy,
+        payout=_W(2100),
+        premium=_W(100),
+        loss_prob=_W("0.03"),
+        expiration=policy.expiration,
+        payer="owner",
+        internal_id=123,
+    )
+
+    pool.access.grant_component_role(rm, "REPLACER_ROLE", "owner")
+
+    balance_before = {}
+    balance_before["JR"] = USD.balance_of(etkJR)
+    balance_before["SR"] = USD.balance_of(etkSR)
+    balance_before["PA"] = USD.balance_of(premiums_account)
+    balance_before["ENS"] = USD.balance_of("ENS")
+    print(balance_before)
+
+    new_policy = rm.replace_policy(**replace_kwargs)
+    rm.active_exposure.assert_equal(_W(2100))
+    etkSR.scr.assert_equal(_W("0.1") * _W(2100))
+    etkJR.scr.assert_equal(new_policy.jr_scr)
+
+    USD.balance_of(etkJR).assert_equal(balance_before["JR"] + new_policy.jr_coc - policy.jr_coc)
+    USD.balance_of(etkSR).assert_equal(balance_before["SR"] + new_policy.sr_coc - policy.sr_coc)
+    USD.balance_of(premiums_account).assert_equal(
+        balance_before["PA"] + new_policy.pure_premium - policy.pure_premium
+    )
+    USD.balance_of("ENS").assert_equal(
+        balance_before["ENS"] + new_policy.ensuro_commission - policy.ensuro_commission
+    )
+
+    # The owner of the first policy is from CUST1 but can't resolve that policy
+    assert pool.owner_of(policy.id) == "CUST1"
+    assert pool.owner_of(new_policy.id) == "CUST1"
+    with pytest.raises(RevertError, match="Policy not found"):
+        rm.resolve_policy(policy.id, True)
+
+
 def test_withdraw_won_premiums(tenv):
     vars = test_expire_policy(tenv)
     pool, premiums_account, USD = extract_vars(vars, "pool,premiums_account,USD")


### PR DESCRIPTION
New feature to support the replacement of a policy with a new upgraded one. The new policy must be greater or equal than the previous one in several aspects:
 - expiration
 - payout
 - pure_premium
 - jr_coc and sr_coc
 - ensuro_fee