### PR TITLE
fix(PolicyPool): delete old policy before _safeMint to prevent replacePolicy reentrancy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,132 @@
+# AGENTS.md — Ensuro
+
+Ensuro is a Solidity smart-contract protocol for blockchain-based insurance/reinsurance. Node 22, Python ≥ 3.12, Solidity 0.8.30 (EVM Prague).
+
+---
+
+## Developer setup (without Docker)
+
+```bash
+python3 -m venv venv && source venv/bin/activate
+pip install -r requirements.txt -r requirements-dev.txt
+nvm use          # switches to Node 22 per .nvmrc
+npm install
+npx hardhat compile   # must run before any tests; artifacts/ is the output
+```
+
+---
+
+## Test suites
+
+There are **two independent test suites** — both must pass.
+
+### Python tests (`tests/`)
+
+Require a live Hardhat node:
+
+```bash
+# Terminal 1 – start the node (or use the helper)
+npx hardhat node
+
+# Terminal 2
+USE_CUSTOM_ERRORS=Y pytest
+```
+
+- `USE_CUSTOM_ERRORS=Y` is required to match how CI runs pytest; omitting it may hide failures.
+- Each test module is parameterized via `TEST_VARIANTS` (default: `["prototype", "ethereum"]`). The `"prototype"` variant runs against the pure-Python model in `prototype/`; the `"ethereum"` variant runs the same test logic against the compiled Solidity contracts over JSON-RPC. Run a single variant: `TEST_VARIANTS=ethereum pytest`.
+- Run a single module: `pytest tests/test_etoken.py`
+- `conftest.py` points `CONTRACT_JSON_PATH` at `artifacts/` — compile first or tests will fail silently.
+
+### JS/Hardhat tests (`test/`)
+
+```bash
+npx hardhat test
+# with gas report:
+REPORT_GAS=1 npx hardhat test
+```
+
+Run a single file:
+
+```bash
+npx hardhat test test/test-etoken.js
+```
+
+---
+
+## Lint / format
+
+```bash
+npm run solhint          # Solidity linting
+npm run prettier         # format contracts/**/*.sol, test/**/*.js, tasks/**/*.js
+black .                  # Python (line-length 110)
+isort .                  # Python import order
+flake8                   # Python lint
+```
+
+Pre-commit hooks enforce all of the above plus gitleaks. Install once with `pre-commit install`.
+
+---
+
+## Coverage
+
+Unified coverage (Python + JS tests instrumented together):
+
+```bash
+USE_CUSTOM_ERRORS=Y npx hardhat python-coverage
+# HTML report: coverage/index.html
+# Cobertura XML: coverage/cobertura-coverage.xml
+```
+
+---
+
+## Other useful commands
+
+```bash
+npx hardhat compile
+npx hardhat size-contracts     # check contract sizes (not run on compile by default)
+npx hardhat python-coverage    # unified coverage
+```
+
+Deploy smoke test (starts its own HH node):
+
+```bash
+scripts/deploySmokeTest.sh
+```
+
+---
+
+## Architecture notes
+
+- **Access control**: contracts use the *Access Managed Proxy* pattern — no `onlyOwner`/`onlyRole` modifiers in the contracts themselves. Access control is delegated to an `AccessManager` via `AccessManagedProxy`. Some high-frequency methods are declared as *skipped* (bypass the proxy check); the canonical list is in `js/ampConfig.js`.
+- **Upgradability**: UUPS proxy pattern throughout.
+- **Contracts**: `PolicyPool`, `EToken`, `RiskModule`, `PremiumsAccount`, `Reserve`, `Cooler`, `LPManualWhitelist`, `Policy` (library). Core logic lives directly in `contracts/`.
+- **Python prototype**: `prototype/ensuro.py` is a Python model of the protocol used as the reference implementation. Python tests run the same test cases against both the prototype and the compiled Solidity.
+- **`tests/wrappers.py` / `prototype/wrappers.py`**: glue code adapting Solidity contract calls to the Python test harness via [ethproto](https://github.com/gnarvaja/eth-prototype).
+
+---
+
+## CI order (tests.yaml)
+
+```
+npm ci + pip install
+→ npx hardhat compile
+→ npx hardhat size-contracts
+→ npm run solhint
+→ pytest (with USE_CUSTOM_ERRORS=Y, HH node started via scripts/utils.sh startHHNode)
+→ scripts/deploySmokeTest.sh
+→ scripts/deploySmokeTest-fork.sh  (needs ALCHEMY_URL secret)
+→ npx hardhat test (with REPORT_GAS=1)
+```
+
+Parallel `coverage` job runs `npx hardhat python-coverage` and publishes Cobertura XML as a PR comment.
+
+---
+
+## Docker (optional)
+
+```bash
+pip install inv-py-docker-k8s-tasks
+inv start-dev    # launch container (ensuro_devenv)
+inv test         # compile + run pytest + JS tests inside container
+inv shell        # shell inside container
+```

--- a/contracts/PolicyPool.sol
+++ b/contracts/PolicyPool.sol
@@ -601,11 +601,13 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
     policy.start = uint40(block.timestamp);
     require(_policies[policy.id] == bytes32(0), PolicyAlreadyExists(policy.id));
     _policies[policy.id] = policy.hash();
-    _safeMint(policyHolder, policy.id, "");
     _changeExposure(rm, true, policy.payout);
 
     // Interactions
     pa.policyCreated(policy);
+    // _safeMint is both an effect (mints the NFT) and an interaction (calls onERC721Received on the holder),
+    // to avoid reentrancy attack, I move it to the interactions section
+    _safeMint(policyHolder, policy.id, "");
 
     // Distribute the premium
     _currency.safeTransferFrom(payer, address(pa), policy.purePremium);
@@ -660,13 +662,15 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
     require(_policies[newPolicy_.id] == bytes32(0), PolicyAlreadyExists(newPolicy_.id));
     _policies[newPolicy_.id] = newPolicy_.hash();
     address policyHolder = ownerOf(oldPolicy.id);
-    _safeMint(policyHolder, newPolicy_.id, "");
     if (newPolicy_.payout > oldPolicy.payout) _changeExposure(rm, true, newPolicy_.payout - oldPolicy.payout);
     else _changeExposure(rm, false, oldPolicy.payout - newPolicy_.payout);
     delete _policies[oldPolicy.id];
 
     // Interactions
     pa.policyReplaced(oldPolicy, newPolicy_);
+    // _safeMint is both an effect (mints the NFT) and an interaction (calls onERC721Received on the holder),
+    // to avoid reentrancy attack, I move it to the interactions section
+    _safeMint(policyHolder, newPolicy_.id, "");
 
     // Distribute the premium
     _transferIfNonZero(payer, address(pa), newPolicy_.purePremium, oldPolicy.purePremium);

--- a/contracts/mocks/ReentrantPolicyHolderMock.sol
+++ b/contracts/mocks/ReentrantPolicyHolderMock.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.28;
+
+import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+
+/**
+ * @title ReentrantPolicyHolderMock
+ * @notice Test helper: arms a reentrant call to fire during onERC721Received.
+ *         Records whether the reentrant call succeeded or failed without
+ *         propagating the error, so the outer transaction can complete.
+ *         Used to verify that the replacePolicy reentrancy fix (deleting the old
+ *         policy before _safeMint) prevents duplicate-accounting attacks.
+ */
+contract ReentrantPolicyHolderMock is IERC721Receiver {
+    address public target;
+    bytes public reentrantCallData;
+    bool public armed;
+    bool public reentryAttempted;
+    bool public reentrySucceeded;
+    bytes public reentryRevertData;
+
+    function arm(address target_, bytes calldata callData_) external {
+        target = target_;
+        reentrantCallData = callData_;
+        armed = true;
+        reentryAttempted = false;
+        reentrySucceeded = false;
+        delete reentryRevertData;
+    }
+
+    function onERC721Received(address, address, uint256, bytes calldata) external override returns (bytes4) {
+        if (armed) {
+            armed = false;
+            reentryAttempted = true;
+            (bool ok, bytes memory returnData) = target.call(reentrantCallData);
+            reentrySucceeded = ok;
+            if (!ok) reentryRevertData = returnData;
+        }
+        return IERC721Receiver.onERC721Received.selector;
+    }
+}

--- a/test/test-replace-policy-reentrancy.js
+++ b/test/test-replace-policy-reentrancy.js
@@ -1,0 +1,149 @@
+/**
+ * Regression tests for the replacePolicy reentrancy fix.
+ *
+ * Before the fix, _safeMint was called before delete _policies[oldPolicy.id], so
+ * the ERC721 receiver callback could reenter with a second lifecycle operation on
+ * the same old policy, creating duplicate active policies with mismatched accounting.
+ *
+ * The fix moves _safeMint to after delete _policies[oldPolicy.id], so any reentrant
+ * attempt to use the old policy fails with PolicyNotFound.
+ *
+ * See: https://gist.github.com/DicksonWu654/063de64666c83a2e5673a58de6d38dfc
+ */
+
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const helpers = require("@nomicfoundation/hardhat-network-helpers");
+const { amountFunction, _W, getTransactionEvent } = require("@ensuro/utils/js/utils");
+const { HOUR } = require("@ensuro/utils/js/constants");
+const { initCurrency } = require("@ensuro/utils/js/test-utils");
+const { deployPool, deployPremiumsAccount, addRiskModule, addEToken } = require("../js/test-utils");
+const {
+  makeFTUWInputData,
+  makeFTUWReplacementInputData,
+  makeFTUWCancelInputData,
+  defaultTestParams,
+} = require("../js/utils");
+
+const _A = amountFunction(6);
+const { MaxUint256 } = ethers;
+
+async function fixture() {
+  const [, lp, backend] = await ethers.getSigners();
+  const currency = await initCurrency(
+    { name: "Test USDC", symbol: "USDC", decimals: 6, initial_supply: _A(100000) },
+    [lp, backend],
+    [_A(20000), _A(5000)]
+  );
+
+  const pool = await deployPool({
+    currency,
+    treasuryAddress: "0x87c47c9a5a2aa74ae714857d64911d9a091c25b1",
+  });
+  pool._A = _A;
+
+  const etk = await addEToken(pool, {});
+  const premiumsAccount = await deployPremiumsAccount(pool, { srEtk: etk });
+
+  const FullTrustedUW = await ethers.getContractFactory("FullTrustedUW");
+  const uw = await FullTrustedUW.deploy();
+
+  const rm = await addRiskModule(pool, premiumsAccount, { underwriter: uw, extraArgs: [] });
+
+  await currency.connect(lp).approve(pool, MaxUint256);
+  await currency.connect(backend).approve(pool, MaxUint256);
+  await pool.connect(lp).deposit(etk, _A(10000), lp);
+
+  const ReentrantHolder = await ethers.getContractFactory("ReentrantPolicyHolderMock");
+  const holder = await ReentrantHolder.deploy();
+
+  return { pool, etk, premiumsAccount, rm, holder, backend };
+}
+
+async function createPolicy({ pool, rm, holder, backend, internalId = 801 }) {
+  const now = await helpers.time.latest();
+  const inputData = makeFTUWInputData({
+    payout: _A(1000),
+    premium: MaxUint256,
+    lossProb: _W("0.01"),
+    expiration: now + 12 * HOUR,
+    internalId,
+    params: defaultTestParams({}),
+  });
+  const tx = await rm.connect(backend).newPolicy(inputData, holder);
+  return getTransactionEvent(pool.interface, await tx.wait(), "NewPolicy").args.policy;
+}
+
+function makeReplacementData(oldPolicy, internalId) {
+  return makeFTUWReplacementInputData({
+    oldPolicy: [...oldPolicy],
+    payout: oldPolicy.payout,
+    premium: MaxUint256,
+    lossProb: oldPolicy.lossProb,
+    expiration: oldPolicy.expiration,
+    internalId,
+    params: defaultTestParams({}),
+  });
+}
+
+describe("replacePolicy reentrancy fix", function () {
+  it("Reentrant replacePolicy during onERC721Received is blocked: old policy deleted before mint", async function () {
+    const { pool, etk, premiumsAccount, rm, holder, backend } = await helpers.loadFixture(fixture);
+
+    const oldPolicy = await createPolicy({ pool, rm, holder, backend });
+
+    // Arm the holder: during the outer replacement's onERC721Received, try a second
+    // replacePolicy on the same old policy (different internalId = different new policy id).
+    const innerInputData = makeReplacementData(oldPolicy, 803);
+    await holder.arm(rm.target, rm.interface.encodeFunctionData("replacePolicy", [innerInputData]));
+
+    const outerInputData = makeReplacementData(oldPolicy, 802);
+    const receipt = await (await rm.connect(backend).replacePolicy(outerInputData)).wait();
+
+    // The callback fired and the reentrant call was attempted...
+    expect(await holder.reentryAttempted()).to.be.true;
+    // ...but it failed because _policies[oldPolicy.id] was already deleted before _safeMint.
+    expect(await holder.reentrySucceeded()).to.be.false;
+
+    // Only one new policy was created, not two.
+    const newPolicies = getTransactionEvent(pool.interface, receipt, "NewPolicy", false);
+    expect(newPolicies.length).to.equal(1);
+
+    // Pool accounting reflects exactly one active policy (the replacement).
+    expect(await premiumsAccount.activePurePremiums()).to.equal(oldPolicy.purePremium);
+    expect(await etk.scr()).to.equal(oldPolicy.srScr);
+    expect((await pool.getExposure(rm))[0]).to.equal(oldPolicy.payout);
+  });
+
+  it("Reentrant cancelPolicy during replacePolicy onERC721Received is blocked: old policy deleted before mint", async function () {
+    const { pool, etk, premiumsAccount, rm, holder, backend } = await helpers.loadFixture(fixture);
+
+    const oldPolicy = await createPolicy({ pool, rm, holder, backend });
+
+    // Arm the holder: during onERC721Received, try to cancel the same old policy.
+    const cancelInputData = makeFTUWCancelInputData({
+      policyToCancel: [...oldPolicy],
+      purePremiumRefund: oldPolicy.purePremium,
+      jrCocRefund: MaxUint256,
+      srCocRefund: MaxUint256,
+    });
+    await holder.arm(rm.target, rm.interface.encodeFunctionData("cancelPolicy", [cancelInputData]));
+
+    const outerInputData = makeReplacementData(oldPolicy, 802);
+    const receipt = await (await rm.connect(backend).replacePolicy(outerInputData)).wait();
+
+    // The callback fired and the reentrant cancellation was attempted...
+    expect(await holder.reentryAttempted()).to.be.true;
+    // ...but failed: old policy was already gone.
+    expect(await holder.reentrySucceeded()).to.be.false;
+
+    // Replacement completed successfully with one new policy.
+    const newPolicies = getTransactionEvent(pool.interface, receipt, "NewPolicy", false);
+    expect(newPolicies.length).to.equal(1);
+
+    // Accounting is consistent with a clean replacement, not a desynchronized state.
+    expect(await premiumsAccount.activePurePremiums()).to.equal(oldPolicy.purePremium);
+    expect(await etk.scr()).to.equal(oldPolicy.srScr);
+    expect((await pool.getExposure(rm))[0]).to.equal(oldPolicy.payout);
+  });
+});


### PR DESCRIPTION
## Summary

`PolicyPool.replacePolicy` called `_safeMint` before `delete _policies[oldPolicy.id]`, so the ERC721 receiver callback on the policy holder could reenter `replacePolicy` or `cancelPolicy` while the old policy was still valid in `_policies`. This allowed an attacker holding two valid lifecycle authorizations for the same active policy to create duplicate active policies with mismatched exposure/SCR/premium accounting.

## Fix

Move `delete _policies[oldPolicy.id]` **before** `_safeMint` in `replacePolicy`, so any reentrant lifecycle call on the old policy fails with `PolicyNotFound`. Also moved `_safeMint` to the interactions section in `newPolicy` for CEI consistency.

## Tests

Added `contracts/mocks/ReentrantPolicyHolderMock.sol` and `test/test-replace-policy-reentrancy.js` covering both attack paths using `FullTrustedUW` (no signature setup required):

- **Path A**: reentrant `replacePolicy` during `onERC721Received` — blocked, only one new policy created, accounting intact
- **Path B**: reentrant `cancelPolicy` during `onERC721Received` — blocked, replacement completes cleanly

## Reference

Reported at: https://gist.github.com/DicksonWu654/063de64666c83a2e5673a58de6d38dfc