### PR TITLE
feat: add newPoliciesBatch for aggregated premium transfers across multiple policies

### DIFF
--- a/contracts/Policy.sol
+++ b/contracts/Policy.sol
@@ -162,6 +162,8 @@ library Policy {
    *
    * @custom:throws PremiumLessThanMinimum when `premium` parameter is less than the computed minPremium
    *
+   * @param rm Address of the risk module
+   * @param internalId Internal id of the policy within the risk module
    * @param rmParams Struct with the business and quantitative parameters that define the risk (see {Params}).
    * @param premium The premium that will be paid for the policy
    * @param payout Maximum payout (exposure) of the policy
@@ -171,6 +173,8 @@ library Policy {
    * @return newPolicy PolicyData struct with the fields initialized (all except .id)
    */
   function initialize(
+    address rm,
+    uint96 internalId,
     Params memory rmParams,
     uint256 premium,
     uint256 payout,
@@ -181,6 +185,7 @@ library Policy {
     require(premium < payout, PremiumExceedsPayout(premium, payout));
     PolicyData memory policy;
 
+    policy.id = makePolicyId(rm, internalId);
     policy.payout = payout;
     policy.lossProb = lossProb;
     policy.start = start;

--- a/contracts/PolicyPool.sol
+++ b/contracts/PolicyPool.sol
@@ -11,6 +11,7 @@ import {MulticallUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/Mu
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+import {AMPUtils} from "@ensuro/access-managed-proxy/contracts/AMPUtils.sol";
 
 import {IEToken} from "./interfaces/IEToken.sol";
 import {IPolicyHolder} from "./interfaces/IPolicyHolder.sol";
@@ -368,6 +369,10 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
     __ERC721_init(name_, symbol_);
     __Pausable_init();
     __PolicyPool_init_unchained(treasury_);
+  }
+
+  function reinitializePashThruMethods(bytes4[] memory newPassThruMethods) public reinitializer(2) {
+    AMPUtils.replacePassThruMethods(newPassThruMethods);
   }
 
   /// @inheritdoc IERC165

--- a/contracts/PolicyPool.sol
+++ b/contracts/PolicyPool.sol
@@ -371,7 +371,7 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
     __PolicyPool_init_unchained(treasury_);
   }
 
-  function reinitializePashThruMethods(bytes4[] memory newPassThruMethods) public reinitializer(2) {
+  function reinitializePassThruMethods(bytes4[] memory newPassThruMethods) public reinitializer(2) {
     AMPUtils.replacePassThruMethods(newPassThruMethods);
   }
 

--- a/contracts/PolicyPool.sol
+++ b/contracts/PolicyPool.sol
@@ -227,6 +227,8 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
   /// @notice Thrown when attempting to execute an action on a policy that does not exist (or was already expired)
   error PolicyNotFound(uint256 policyId);
 
+  error NewPoliciesMustStartNow();
+
   /**
    * @notice Thrown when attempting to expire a policy, but the policy is still active (policy.expiration >
    * block.timestamp)
@@ -589,13 +591,10 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
   function _newPolicyEffects(
     IRiskModule rm,
     IPremiumsAccount pa,
-    Policy.PolicyData memory policy,
-    uint96 internalId,
+    Policy.PolicyData calldata policy,
     address policyHolder
   ) internal {
     // Effects
-    policy.id = Policy.makePolicyId(address(rm), internalId);
-    policy.start = uint40(block.timestamp);
     require(_policies[policy.id] == bytes32(0), PolicyAlreadyExists(policy.id));
     _policies[policy.id] = policy.hash();
     _changeExposure(rm, true, policy.payout);
@@ -616,15 +615,16 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
 
   /// @inheritdoc IPolicyPool
   function newPolicy(
-    Policy.PolicyData memory policy,
+    Policy.PolicyData calldata policy,
     address payer,
-    address policyHolder,
-    uint96 internalId
-  ) external override whenNotPaused returns (uint256) {
+    address policyHolder
+  ) external override whenNotPaused {
     // Checks
     (IRiskModule rm, IPremiumsAccount pa) = _validateRMAndPAActive();
+    require(Policy.extractRiskModule(policy.id) == address(rm), OnlyRiskModuleAllowed());
+    require(policy.start == block.timestamp, NewPoliciesMustStartNow());
 
-    _newPolicyEffects(rm, pa, policy, internalId, policyHolder);
+    _newPolicyEffects(rm, pa, policy, policyHolder);
 
     // Distribute the premium
     _currency.safeTransferFrom(payer, address(pa), policy.purePremium);
@@ -641,27 +641,28 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
      */
 
     emit NewPolicy(rm, policy);
-    return policy.id;
   }
 
+  /// @inheritdoc IPolicyPool
   function newPoliciesBatch(
-    Policy.PolicyData[] memory policies,
+    Policy.PolicyData[] calldata policies,
     address payer,
-    address policyHolder,
-    uint96[] memory internalIds
+    address policyHolder
   ) external override whenNotPaused {
     // Checks
     (IRiskModule rm, IPremiumsAccount pa) = _validateRMAndPAActive();
-    require(policies.length == internalIds.length, BatchInputLengthMismatch(policies.length, internalIds.length));
 
     uint256 purePremiumSum;
     uint256 srCocSum;
     uint256 jrCocSum;
     uint256 ensuroCommissionSum;
     uint256 partnerCommissionSum;
+    uint40 now_ = uint40(block.timestamp);
 
     for (uint256 i = 0; i < policies.length; ++i) {
-      _newPolicyEffects(rm, pa, policies[i], internalIds[i], policyHolder);
+      require(Policy.extractRiskModule(policies[i].id) == address(rm), OnlyRiskModuleAllowed());
+      require(policies[i].start == now_, NewPoliciesMustStartNow());
+      _newPolicyEffects(rm, pa, policies[i], policyHolder);
       purePremiumSum += policies[i].purePremium;
       srCocSum += policies[i].srCoc;
       jrCocSum += policies[i].jrCoc;
@@ -684,14 +685,16 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
   // solhint-disable-next-line function-max-lines
   function replacePolicy(
     Policy.PolicyData calldata oldPolicy,
-    Policy.PolicyData memory newPolicy_,
-    address payer,
-    uint96 internalId
-  ) external override whenNotPaused returns (uint256) {
+    Policy.PolicyData calldata newPolicy_,
+    address payer
+  ) external override whenNotPaused {
     // Checks
     _validatePolicy(oldPolicy);
     (IRiskModule rm, IPremiumsAccount pa) = _validateRMAndPAActive();
-    if (Policy.extractRiskModule(oldPolicy.id) != address(rm)) revert OnlyRiskModuleAllowed();
+    require(
+      Policy.extractRiskModule(oldPolicy.id) == address(rm) && Policy.extractRiskModule(newPolicy_.id) == address(rm),
+      OnlyRiskModuleAllowed()
+    );
     require(
       oldPolicy.expiration > uint40(block.timestamp) && newPolicy_.expiration >= uint40(block.timestamp),
       PolicyAlreadyExpired(oldPolicy.id)
@@ -708,7 +711,6 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
     // payout, jrScr, srScr, expiration can change in any direction
 
     // Effects
-    newPolicy_.id = Policy.makePolicyId(address(rm), internalId);
     require(_policies[newPolicy_.id] == bytes32(0), PolicyAlreadyExists(newPolicy_.id));
     _policies[newPolicy_.id] = newPolicy_.hash();
     address policyHolder = ownerOf(oldPolicy.id);
@@ -740,7 +742,6 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
     emit NewPolicy(rm, newPolicy_);
     emit PolicyReplaced(rm, oldPolicy.id, newPolicy_.id);
     _notifyReplacement(oldPolicy.id, newPolicy_.id);
-    return newPolicy_.id;
   }
 
   /// @inheritdoc IPolicyPool
@@ -753,7 +754,7 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
     // Checks
     _validatePolicy(policyToCancel);
     IRiskModule rm = IRiskModule(_msgSender());
-    if (Policy.extractRiskModule(policyToCancel.id) != address(rm)) revert OnlyRiskModuleAllowed();
+    require(Policy.extractRiskModule(policyToCancel.id) == address(rm), OnlyRiskModuleAllowed());
     _requireCompActiveOrDeprecated(address(rm), ComponentKind.riskModule);
     IPremiumsAccount pa = rm.premiumsAccount();
     _requireCompActiveOrDeprecated(address(pa), ComponentKind.premiumsAccount);

--- a/contracts/PolicyPool.sol
+++ b/contracts/PolicyPool.sol
@@ -274,9 +274,6 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
   /// @notice Thrown when an invalid receiver address (address(0)) is provided as received of deposit or withdraw
   error InvalidReceiver(address receiver);
 
-  /// @notice Thrown when batch input arrays have different lengths
-  error BatchInputLengthMismatch(uint256 policiesLength, uint256 internalIdsLength);
-
   /**
    * @notice Event emitted when the treasury (who receives ensuroCommission) changes
    *
@@ -613,6 +610,27 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
     _requireCompActive(address(pa), ComponentKind.premiumsAccount);
   }
 
+  function _distributePremium(
+    address payer,
+    IPremiumsAccount pa,
+    IRiskModule rm,
+    uint256 purePremium,
+    uint256 srCoc,
+    uint256 jrCoc,
+    uint256 ensuroCommission,
+    uint256 partnerCommission
+  ) internal {
+    if (purePremium > 0) _currency.safeTransferFrom(payer, address(pa), purePremium);
+    (IEToken jrEtk, IEToken srEtk) = pa.etks();
+    if (srCoc > 0) _currency.safeTransferFrom(payer, address(srEtk), srCoc);
+    if (jrCoc > 0) _currency.safeTransferFrom(payer, address(jrEtk), jrCoc);
+    if (ensuroCommission > 0) _currency.safeTransferFrom(payer, _treasury, ensuroCommission);
+    if (partnerCommission > 0) {
+      address partnerAddress = rm.wallet();
+      if (payer != partnerAddress) _currency.safeTransferFrom(payer, partnerAddress, partnerCommission);
+    }
+  }
+
   /// @inheritdoc IPolicyPool
   function newPolicy(
     Policy.PolicyData calldata policy,
@@ -626,20 +644,16 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
 
     _newPolicyEffects(rm, pa, policy, policyHolder);
 
-    // Distribute the premium
-    _currency.safeTransferFrom(payer, address(pa), policy.purePremium);
-    (IEToken jrEtk, IEToken srEtk) = pa.etks();
-    if (policy.srCoc > 0) _currency.safeTransferFrom(payer, address(srEtk), policy.srCoc);
-    if (policy.jrCoc > 0) _currency.safeTransferFrom(payer, address(jrEtk), policy.jrCoc);
-    _currency.safeTransferFrom(payer, _treasury, policy.ensuroCommission);
-    if (policy.partnerCommission > 0 && payer != rm.wallet())
-      _currency.safeTransferFrom(payer, rm.wallet(), policy.partnerCommission);
-    /**
-     * This code does up to 5 ERC20 transfers. This can be avoided to reduce the gas cost, by implementing delayed
-     * transfers. This might be considered in the future, but to avoid increasing the complexity and since so far we
-     * operate on low gas-cost blockchains, we keep it as it is.
-     */
-
+    _distributePremium(
+      payer,
+      pa,
+      rm,
+      policy.purePremium,
+      policy.srCoc,
+      policy.jrCoc,
+      policy.ensuroCommission,
+      policy.partnerCommission
+    );
     emit NewPolicy(rm, policy);
   }
 
@@ -671,14 +685,7 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
       emit NewPolicy(rm, policies[i]);
     }
 
-    // Distribute the premium
-    _currency.safeTransferFrom(payer, address(pa), purePremiumSum);
-    (IEToken jrEtk, IEToken srEtk) = pa.etks();
-    if (srCocSum > 0) _currency.safeTransferFrom(payer, address(srEtk), srCocSum);
-    if (jrCocSum > 0) _currency.safeTransferFrom(payer, address(jrEtk), jrCocSum);
-    _currency.safeTransferFrom(payer, _treasury, ensuroCommissionSum);
-    if (partnerCommissionSum > 0 && payer != rm.wallet())
-      _currency.safeTransferFrom(payer, rm.wallet(), partnerCommissionSum);
+    _distributePremium(payer, pa, rm, purePremiumSum, srCocSum, jrCocSum, ensuroCommissionSum, partnerCommissionSum);
   }
 
   /// @inheritdoc IPolicyPool
@@ -724,20 +731,16 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
     // to avoid reentrancy attack, I move it to the interactions section
     _safeMint(policyHolder, newPolicy_.id, "");
 
-    // Distribute the premium
-    _transferIfNonZero(payer, address(pa), newPolicy_.purePremium, oldPolicy.purePremium);
-    (IEToken jrEtk, IEToken srEtk) = pa.etks();
-    _transferIfNonZero(payer, address(srEtk), newPolicy_.srCoc, oldPolicy.srCoc);
-    _transferIfNonZero(payer, address(jrEtk), newPolicy_.jrCoc, oldPolicy.jrCoc);
-    _transferIfNonZero(payer, _treasury, newPolicy_.ensuroCommission, oldPolicy.ensuroCommission);
-    address rmWallet = rm.wallet();
-    if (payer != rmWallet)
-      _transferIfNonZero(payer, rmWallet, newPolicy_.partnerCommission, oldPolicy.partnerCommission);
-    /**
-     * This code does up to 5 ERC20 transfers. This can be avoided to reduce the gas cost, by implementing delayed
-     * transfers. This might be considered in the future, but to avoid increasing the complexity and since so far we
-     * operate on low gas-cost blockchains, we keep it as it is.
-     */
+    _distributePremium(
+      payer,
+      pa,
+      rm,
+      newPolicy_.purePremium - oldPolicy.purePremium,
+      newPolicy_.srCoc - oldPolicy.srCoc,
+      newPolicy_.jrCoc - oldPolicy.jrCoc,
+      newPolicy_.ensuroCommission - oldPolicy.ensuroCommission,
+      newPolicy_.partnerCommission - oldPolicy.partnerCommission
+    );
 
     emit NewPolicy(rm, newPolicy_);
     emit PolicyReplaced(rm, oldPolicy.id, newPolicy_.id);
@@ -776,13 +779,6 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
 
     emit PolicyCancelled(rm, policyToCancel.id, purePremiumRefund, jrCocRefund, srCocRefund);
     _notifyCancellation(policyToCancel.id, purePremiumRefund, jrCocRefund, srCocRefund);
-  }
-
-  function _transferIfNonZero(address payer, address target, uint256 new_, uint256 old_) internal {
-    uint256 aux = new_ - old_;
-    if (aux != 0) {
-      _currency.safeTransferFrom(payer, target, aux);
-    }
   }
 
   function _validatePolicy(Policy.PolicyData memory policy) internal view {

--- a/contracts/PolicyPool.sol
+++ b/contracts/PolicyPool.sol
@@ -272,6 +272,9 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
   /// @notice Thrown when an invalid receiver address (address(0)) is provided as received of deposit or withdraw
   error InvalidReceiver(address receiver);
 
+  /// @notice Thrown when batch input arrays have different lengths
+  error BatchInputLengthMismatch(uint256 policiesLength, uint256 internalIdsLength);
+
   /**
    * @notice Event emitted when the treasury (who receives ensuroCommission) changes
    *
@@ -583,19 +586,13 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
     emit Withdraw(eToken, _msgSender(), receiver, owner, amountWithdrawn);
   }
 
-  /// @inheritdoc IPolicyPool
-  function newPolicy(
+  function _newPolicyEffects(
+    IRiskModule rm,
+    IPremiumsAccount pa,
     Policy.PolicyData memory policy,
-    address payer,
-    address policyHolder,
-    uint96 internalId
-  ) external override whenNotPaused returns (uint256) {
-    // Checks
-    IRiskModule rm = IRiskModule(_msgSender());
-    _requireCompActive(address(rm), ComponentKind.riskModule);
-    IPremiumsAccount pa = rm.premiumsAccount();
-    _requireCompActive(address(pa), ComponentKind.premiumsAccount);
-
+    uint96 internalId,
+    address policyHolder
+  ) internal {
     // Effects
     policy.id = Policy.makePolicyId(address(rm), internalId);
     policy.start = uint40(block.timestamp);
@@ -608,6 +605,26 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
     // _safeMint is both an effect (mints the NFT) and an interaction (calls onERC721Received on the holder),
     // to avoid reentrancy attack, I move it to the interactions section
     _safeMint(policyHolder, policy.id, "");
+  }
+
+  function _validateRMAndPAActive() internal view returns (IRiskModule rm, IPremiumsAccount pa) {
+    rm = IRiskModule(_msgSender());
+    _requireCompActive(address(rm), ComponentKind.riskModule);
+    pa = rm.premiumsAccount();
+    _requireCompActive(address(pa), ComponentKind.premiumsAccount);
+  }
+
+  /// @inheritdoc IPolicyPool
+  function newPolicy(
+    Policy.PolicyData memory policy,
+    address payer,
+    address policyHolder,
+    uint96 internalId
+  ) external override whenNotPaused returns (uint256) {
+    // Checks
+    (IRiskModule rm, IPremiumsAccount pa) = _validateRMAndPAActive();
+
+    _newPolicyEffects(rm, pa, policy, internalId, policyHolder);
 
     // Distribute the premium
     _currency.safeTransferFrom(payer, address(pa), policy.purePremium);
@@ -627,6 +644,42 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
     return policy.id;
   }
 
+  function newPoliciesBatch(
+    Policy.PolicyData[] memory policies,
+    address payer,
+    address policyHolder,
+    uint96[] memory internalIds
+  ) external override whenNotPaused {
+    // Checks
+    (IRiskModule rm, IPremiumsAccount pa) = _validateRMAndPAActive();
+    require(policies.length == internalIds.length, BatchInputLengthMismatch(policies.length, internalIds.length));
+
+    uint256 purePremiumSum;
+    uint256 srCocSum;
+    uint256 jrCocSum;
+    uint256 ensuroCommissionSum;
+    uint256 partnerCommissionSum;
+
+    for (uint256 i = 0; i < policies.length; ++i) {
+      _newPolicyEffects(rm, pa, policies[i], internalIds[i], policyHolder);
+      purePremiumSum += policies[i].purePremium;
+      srCocSum += policies[i].srCoc;
+      jrCocSum += policies[i].jrCoc;
+      ensuroCommissionSum += policies[i].ensuroCommission;
+      partnerCommissionSum += policies[i].partnerCommission;
+      emit NewPolicy(rm, policies[i]);
+    }
+
+    // Distribute the premium
+    _currency.safeTransferFrom(payer, address(pa), purePremiumSum);
+    (IEToken jrEtk, IEToken srEtk) = pa.etks();
+    if (srCocSum > 0) _currency.safeTransferFrom(payer, address(srEtk), srCocSum);
+    if (jrCocSum > 0) _currency.safeTransferFrom(payer, address(jrEtk), jrCocSum);
+    _currency.safeTransferFrom(payer, _treasury, ensuroCommissionSum);
+    if (partnerCommissionSum > 0 && payer != rm.wallet())
+      _currency.safeTransferFrom(payer, rm.wallet(), partnerCommissionSum);
+  }
+
   /// @inheritdoc IPolicyPool
   // solhint-disable-next-line function-max-lines
   function replacePolicy(
@@ -637,11 +690,8 @@ contract PolicyPool is IPolicyPool, PausableUpgradeable, UUPSUpgradeable, ERC721
   ) external override whenNotPaused returns (uint256) {
     // Checks
     _validatePolicy(oldPolicy);
-    IRiskModule rm = IRiskModule(_msgSender());
+    (IRiskModule rm, IPremiumsAccount pa) = _validateRMAndPAActive();
     if (Policy.extractRiskModule(oldPolicy.id) != address(rm)) revert OnlyRiskModuleAllowed();
-    _requireCompActive(address(rm), ComponentKind.riskModule);
-    IPremiumsAccount pa = rm.premiumsAccount();
-    _requireCompActive(address(pa), ComponentKind.premiumsAccount);
     require(
       oldPolicy.expiration > uint40(block.timestamp) && newPolicy_.expiration >= uint40(block.timestamp),
       PolicyAlreadyExpired(oldPolicy.id)

--- a/contracts/RiskModule.sol
+++ b/contracts/RiskModule.sol
@@ -172,9 +172,28 @@ contract RiskModule is IRiskModule, PolicyPoolComponent {
    * @param onBehalfOf The address that will be the owner of the created policy (same for all the policies)
    */
   function newPolicies(bytes[] calldata inputData, address onBehalfOf) external {
+    Policy.PolicyData[] memory policies = new Policy.PolicyData[](inputData.length);
+    uint96[] memory internalIds = new uint96[](inputData.length);
+    uint40 now_ = uint40(block.timestamp);
+    require(onBehalfOf != address(0), InvalidCustomer(onBehalfOf));
+
     for (uint256 i = 0; i < inputData.length; ++i) {
-      newPolicy(inputData[i], onBehalfOf);
+      (
+        uint256 payout,
+        uint256 premium,
+        uint256 lossProb,
+        uint40 expiration,
+        uint96 internalId,
+        Policy.Params memory params_
+      ) = _underwriter.priceNewPolicy(address(this), inputData[i]);
+      if (premium == type(uint256).max) {
+        premium = getMinimumPremium(payout, lossProb, now_, expiration, params_);
+      }
+      require(expiration > now_, ExpirationMustBeInTheFuture(expiration, now_));
+      policies[i] = Policy.initialize(params_, premium, payout, lossProb, expiration, now_);
+      internalIds[i] = internalId;
     }
+    _policyPool.newPoliciesBatch(policies, msg.sender, onBehalfOf, internalIds);
   }
 
   /**

--- a/contracts/RiskModule.sol
+++ b/contracts/RiskModule.sol
@@ -159,8 +159,8 @@ contract RiskModule is IRiskModule, PolicyPoolComponent {
     }
     require(expiration > now_, ExpirationMustBeInTheFuture(expiration, now_));
     require(onBehalfOf != address(0), InvalidCustomer(onBehalfOf));
-    policy = Policy.initialize(params_, premium, payout, lossProb, expiration, now_);
-    policy.id = _policyPool.newPolicy(policy, msg.sender, onBehalfOf, internalId);
+    policy = Policy.initialize(address(this), internalId, params_, premium, payout, lossProb, expiration, now_);
+    _policyPool.newPolicy(policy, msg.sender, onBehalfOf);
     return policy;
   }
 
@@ -173,7 +173,6 @@ contract RiskModule is IRiskModule, PolicyPoolComponent {
    */
   function newPolicies(bytes[] calldata inputData, address onBehalfOf) external {
     Policy.PolicyData[] memory policies = new Policy.PolicyData[](inputData.length);
-    uint96[] memory internalIds = new uint96[](inputData.length);
     uint40 now_ = uint40(block.timestamp);
     require(onBehalfOf != address(0), InvalidCustomer(onBehalfOf));
 
@@ -190,10 +189,9 @@ contract RiskModule is IRiskModule, PolicyPoolComponent {
         premium = getMinimumPremium(payout, lossProb, now_, expiration, params_);
       }
       require(expiration > now_, ExpirationMustBeInTheFuture(expiration, now_));
-      policies[i] = Policy.initialize(params_, premium, payout, lossProb, expiration, now_);
-      internalIds[i] = internalId;
+      policies[i] = Policy.initialize(address(this), internalId, params_, premium, payout, lossProb, expiration, now_);
     }
-    _policyPool.newPoliciesBatch(policies, msg.sender, onBehalfOf, internalIds);
+    _policyPool.newPoliciesBatch(policies, msg.sender, onBehalfOf);
   }
 
   /**
@@ -217,9 +215,18 @@ contract RiskModule is IRiskModule, PolicyPoolComponent {
       premium = getMinimumPremium(payout, lossProb, oldPolicy.start, expiration, params_);
     }
     if (expiration < uint40(block.timestamp)) revert ExpirationMustBeInTheFuture(expiration, uint40(block.timestamp));
-    policy = Policy.initialize(params_, premium, payout, lossProb, expiration, oldPolicy.start);
+    policy = Policy.initialize(
+      address(this),
+      internalId,
+      params_,
+      premium,
+      payout,
+      lossProb,
+      expiration,
+      oldPolicy.start
+    );
 
-    policy.id = _policyPool.replacePolicy(oldPolicy, policy, msg.sender, internalId);
+    _policyPool.replacePolicy(oldPolicy, policy, msg.sender);
 
     return policy;
   }

--- a/contracts/interfaces/IPolicyPool.sol
+++ b/contracts/interfaces/IPolicyPool.sol
@@ -81,33 +81,48 @@ interface IPolicyPool {
    * @custom:pre `msg.sender` must be an active RiskModule
    * @custom:pre `rm.premiumsAccount()` must be an active PremiumsAccount
    * @custom:pre `payer` approved the spending of `currency()` for at least `policy.premium`
-   * @custom:pre `internalId` must be unique within the risk module (`msg.sender`) and not used before
+   * @custom:pre `policy.id` must be `Policy.makePolicyId(rm, internalId)` and not used before
+   * @custom:pre `policy.start` must be equal to `block.timestamp`
    *
    * @custom:emits NewPolicy with all the details about the policy
    * @custom:emits ERC20-Transfer transfers from `payer` to the different receivers of the premium
    *               (see Premium Split in the docs)
    *
    * @custom:throws PolicyAlreadyExists when reusing an internalId
-
+   * @custom:throws NewPoliciesMustStartNow when `policy.start != block.timestamp`
+   *
    * @param policy A policy created with {Policy-initialize}
    * @param payer The address that will pay for the premium
    * @param policyHolder The address of the policy holder
-   * @param internalId A unique id within the RiskModule, that will be used to compute the policy id
-   * @return The policy id, identifying the NFT and the policy
    */
-  function newPolicy(
-    Policy.PolicyData memory policy,
-    address payer,
-    address policyHolder,
-    uint96 internalId
-  ) external returns (uint256);
+  function newPolicy(Policy.PolicyData calldata policy, address payer, address policyHolder) external;
 
-  function newPoliciesBatch(
-    Policy.PolicyData[] memory policies,
-    address payer,
-    address policyHolder,
-    uint96[] memory internalIds
-  ) external;
+  /**
+   * @notice Creates multiple policies in a single call, aggregating premium transfers
+   * @dev It charges the sum of all premiums and distributes it to the different parties
+   *      (PremiumsAccount, ETokens, treasury) in a single transfer per component, instead of
+   *      one transfer per policy. This reduces the number of ERC20 transfers from 5N to 5
+   *      for N policies.
+   *
+   * @custom:pre `msg.sender` must be an active RiskModule
+   * @custom:pre `rm.premiumsAccount()` must be an active PremiumsAccount
+   * @custom:pre `payer` approved the spending of `currency()` for at least the sum of all premiums
+   * @custom:pre Each `policies[i].start` must be equal to `block.timestamp`
+   * @custom:pre Each `policies[i].id` must be unique and not used before
+   *
+   * @custom:emits NewPolicy for each policy with all the details
+   * @custom:emits ERC20-Transfer transfers from `payer` to the different receivers of the premium
+   *               (see Premium Split in the docs)
+   *
+   * @custom:throws NewPoliciesMustStartNow when `policies[i].start != block.timestamp`
+   * @custom:throws PolicyAlreadyExists when reusing a policy id
+   * @custom:throws OnlyRiskModuleAllowed when `policies[i].id` doesn't match the sender risk module
+   *
+   * @param policies An array of policies created with {Policy-initialize}
+   * @param payer The address that will pay for the premium
+   * @param policyHolder The address that will own the minted policy NFTs (same for all policies)
+   */
+  function newPoliciesBatch(Policy.PolicyData[] calldata policies, address payer, address policyHolder) external;
 
   /**
    * @notice Replaces a policy with another
@@ -117,13 +132,11 @@ interface IPolicyPool {
    * @param oldPolicy A policy created previously and not expired
    * @param newPolicy_ A policy created with {Policy-initialize}
    * @param payer The address that will pay for the premium difference
-   * @param internalId A unique id within the RiskModule, that will be used to compute the policy id
-   * @return The policy id, identifying the NFT and the policy
    *
    * @custom:pre `msg.sender` must be an active RiskModule
    * @custom:pre `rm.premiumsAccount()` must be an active PremiumsAccount
    * @custom:pre `payer` approved the spending of `currency()` for at least `newPolicy_.premium - oldPolicy.premium`
-   * @custom:pre `internalId` must be unique within `policy.riskModule` and not used before
+   * @custom:pre `newPolicy_.id` must be `Policy.makePolicyId(rm, internalId)` and not used before
    *
    * @custom:throws PolicyAlreadyExpired when trying to replace an expired policy
    * @custom:throws InvalidPolicyReplacement when trying to reduce some of the premium componentsa
@@ -132,11 +145,10 @@ interface IPolicyPool {
    * @custom:emits NewPolicy with all the details of the new policy
    */
   function replacePolicy(
-    Policy.PolicyData memory oldPolicy,
-    Policy.PolicyData memory newPolicy_,
-    address payer,
-    uint96 internalId
-  ) external returns (uint256);
+    Policy.PolicyData calldata oldPolicy,
+    Policy.PolicyData calldata newPolicy_,
+    address payer
+  ) external;
 
   /**
    * @notice Cancels a policy, doing optional refunds of parts of the premium.

--- a/contracts/interfaces/IPolicyPool.sol
+++ b/contracts/interfaces/IPolicyPool.sol
@@ -102,6 +102,13 @@ interface IPolicyPool {
     uint96 internalId
   ) external returns (uint256);
 
+  function newPoliciesBatch(
+    Policy.PolicyData[] memory policies,
+    address payer,
+    address policyHolder,
+    uint96[] memory internalIds
+  ) external;
+
   /**
    * @notice Replaces a policy with another
    * @dev After this call, the oldPolicy is no longer active and a new policy is created. Diferencial changes to

--- a/contracts/mocks/PolicyPoolMock.sol
+++ b/contracts/mocks/PolicyPoolMock.sol
@@ -31,42 +31,34 @@ contract PolicyPoolMock is IPolicyPool {
   }
 
   function newPolicy(
-    Policy.PolicyData memory policy,
+    Policy.PolicyData calldata policy,
     address /* payer */,
-    address /* policyHolder */,
-    uint96 internalId
-  ) external override returns (uint256) {
-    policy.id = (uint256(uint160(msg.sender)) << 96) + internalId;
+    address /* policyHolder */
+  ) external override {
     policyHashes[policy.id] = policy.hash();
     emit NewPolicy(IRiskModule(msg.sender), policy);
-    return policy.id;
   }
 
   function newPoliciesBatch(
-    Policy.PolicyData[] memory policies,
+    Policy.PolicyData[] calldata policies,
     address payer,
-    address policyHolder,
-    uint96[] memory internalIds
+    address policyHolder
   ) external override {
     for (uint256 i = 0; i < policies.length; ++i) {
-      policies[i].id = (uint256(uint160(msg.sender)) << 96) + internalIds[i];
       policyHashes[policies[i].id] = policies[i].hash();
       emit NewPolicy(IRiskModule(msg.sender), policies[i]);
     }
   }
 
   function replacePolicy(
-    Policy.PolicyData memory oldPolicy,
-    Policy.PolicyData memory newPolicy_,
-    address /* payer */,
-    uint96 internalId
-  ) external override returns (uint256) {
-    newPolicy_.id = (uint256(uint160(msg.sender)) << 96) + internalId;
+    Policy.PolicyData calldata oldPolicy,
+    Policy.PolicyData calldata newPolicy_,
+    address /* payer */
+  ) external override {
     policyHashes[newPolicy_.id] = newPolicy_.hash();
     IRiskModule rm = IRiskModule(msg.sender);
     emit NewPolicy(rm, newPolicy_);
     emit PolicyReplaced(IRiskModule(msg.sender), oldPolicy.id, newPolicy_.id);
-    return newPolicy_.id;
   }
 
   function cancelPolicy(
@@ -120,6 +112,8 @@ contract PolicyPoolMock is IPolicyPool {
    * @dev Simple passthrough method for testing Policy.initialize
    */
   function initializeAndEmitPolicy(
+    address rm,
+    uint96 internalId,
     Policy.Params memory rmParams,
     uint256 premium,
     uint256 payout,
@@ -128,6 +122,8 @@ contract PolicyPoolMock is IPolicyPool {
     uint40 start
   ) external {
     Policy.PolicyData memory policy = Policy.initialize(
+      rm,
+      internalId,
       rmParams,
       premium,
       payout,

--- a/contracts/mocks/PolicyPoolMock.sol
+++ b/contracts/mocks/PolicyPoolMock.sol
@@ -42,6 +42,19 @@ contract PolicyPoolMock is IPolicyPool {
     return policy.id;
   }
 
+  function newPoliciesBatch(
+    Policy.PolicyData[] memory policies,
+    address payer,
+    address policyHolder,
+    uint96[] memory internalIds
+  ) external override {
+    for (uint256 i = 0; i < policies.length; ++i) {
+      policies[i].id = (uint256(uint160(msg.sender)) << 96) + internalIds[i];
+      policyHashes[policies[i].id] = policies[i].hash();
+      emit NewPolicy(IRiskModule(msg.sender), policies[i]);
+    }
+  }
+
   function replacePolicy(
     Policy.PolicyData memory oldPolicy,
     Policy.PolicyData memory newPolicy_,

--- a/contracts/mocks/RiskModuleMock.sol
+++ b/contracts/mocks/RiskModuleMock.sol
@@ -5,6 +5,7 @@ import {IPolicyPool} from "../interfaces/IPolicyPool.sol";
 import {IPremiumsAccount} from "../interfaces/IPremiumsAccount.sol";
 import {IRiskModule} from "../interfaces/IRiskModule.sol";
 import {IPolicyPoolComponent} from "../interfaces/IPolicyPoolComponent.sol";
+import {Policy} from "../Policy.sol";
 import {ForwardProxy} from "./ForwardProxy.sol";
 
 contract RiskModuleMock is ForwardProxy, IRiskModule, IPolicyPoolComponent {
@@ -37,5 +38,20 @@ contract RiskModuleMock is ForwardProxy, IRiskModule, IPolicyPoolComponent {
 
   function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
     return interfaceId == type(IRiskModule).interfaceId;
+  }
+
+  function newPolicy(Policy.PolicyData calldata policy, address payer, address policyHolder) external {
+    Policy.PolicyData memory p = policy;
+    if (p.start == 0) p.start = uint40(block.timestamp);
+    IPolicyPool(_forwardTo).newPolicy(p, payer, policyHolder);
+  }
+
+  function newPoliciesBatch(Policy.PolicyData[] calldata policies, address payer, address policyHolder) external {
+    Policy.PolicyData[] memory p = new Policy.PolicyData[](policies.length);
+    for (uint256 i = 0; i < policies.length; i++) {
+      p[i] = policies[i];
+      if (p[i].start == 0) p[i].start = uint40(block.timestamp);
+    }
+    IPolicyPool(_forwardTo).newPoliciesBatch(p, payer, policyHolder);
   }
 }

--- a/js/ampConfig.js
+++ b/js/ampConfig.js
@@ -3,6 +3,7 @@ const ampConfig = {
     skipViewsAndPure: true,
     skipMethods: [
       "newPolicy",
+      "newPoliciesBatch",
       "resolvePolicy",
       "replacePolicy",
       "expirePolicy", // To guarantee that all policies expire

--- a/test/test-policy-holder-contract.js
+++ b/test/test-policy-holder-contract.js
@@ -19,9 +19,10 @@ const NotificationKind = {
   PolicyCancelled: 4,
 };
 
-function toPolicyStruct(policy, start = 0) {
+function toPolicyStruct(policy, rm, internalId, start = 0) {
+  const policyId = makePolicyId(rm, internalId);
   return [
-    0, // id - Ignored
+    policyId,
     policy.payout, // payout
     _A(0), // jrScr
     _A(0), // srScr
@@ -40,7 +41,7 @@ describe("PoliyHolder policy creation handling", () => {
   it("Receiving with a functioning holder contract succeeds and executes the handler code", async () => {
     const { rm, ph, backend } = await helpers.loadFixture(deployPoolFixture);
     const policy = await defaultPolicyParams({});
-    await expect(rm.newPolicy(toPolicyStruct(policy), backend, ph, 1))
+    await expect(rm.newPolicy(toPolicyStruct(policy, rm, 1), backend, ph))
       .to.emit(ph, "NotificationReceived")
       .withArgs(NotificationKind.PolicyReceived, makePolicyId(rm, 1), rm, ZeroAddress);
   });
@@ -49,7 +50,7 @@ describe("PoliyHolder policy creation handling", () => {
     const { rm, ph, backend } = await helpers.loadFixture(deployPoolFixture);
     const policy = await defaultPolicyParams({});
     await ph.setFail(true);
-    await expect(rm.newPolicy(toPolicyStruct(policy), backend, ph, 1)).to.be.revertedWith(
+    await expect(rm.newPolicy(toPolicyStruct(policy, rm, 1), backend, ph)).to.be.revertedWith(
       "onERC721Received: They told me I have to fail"
     );
   });
@@ -59,7 +60,7 @@ describe("PoliyHolder policy creation handling", () => {
     const policy = await defaultPolicyParams({});
     await ph.setFail(true);
     await ph.setEmptyRevert(true);
-    await expect(rm.newPolicy(toPolicyStruct(policy), backend, ph, 1)).to.be.revertedWithCustomError(
+    await expect(rm.newPolicy(toPolicyStruct(policy, rm, 1), backend, ph)).to.be.revertedWithCustomError(
       pool,
       "ERC721InvalidReceiver"
     );
@@ -69,7 +70,7 @@ describe("PoliyHolder policy creation handling", () => {
     const { rm, ph, backend, pool } = await helpers.loadFixture(deployPoolFixture);
     const policy = await defaultPolicyParams({});
     await ph.setBadlyImplemented(true);
-    await expect(rm.newPolicy(toPolicyStruct(policy), backend, ph, 1)).to.be.revertedWithCustomError(
+    await expect(rm.newPolicy(toPolicyStruct(policy, rm, 1), backend, ph)).to.be.revertedWithCustomError(
       pool,
       "ERC721InvalidReceiver"
     );
@@ -152,7 +153,7 @@ describe("PolicyHolder replacement handling", () => {
     const chainPolicy = policyEvt.args.policy;
     const policyNew = await defaultPolicyParams({ expiration: policy.expiration, premium: chainPolicy.premium });
     const replaceReceipt = await getReceipt(
-      rm.replacePolicy([...chainPolicy], toPolicyStruct(policyNew, chainPolicy.start), backend, 2)
+      rm.replacePolicy([...chainPolicy], toPolicyStruct(policyNew, rm, 2, chainPolicy.start), backend)
     );
 
     const evts = getTransactionEvent(ph.interface, replaceReceipt, "NotificationReceived", false, getAddress(ph));
@@ -173,7 +174,7 @@ describe("PolicyHolder replacement handling", () => {
 
     await ph.setSpendGasCount(10);
     const replaceReceipt = await getReceipt(
-      rm.replacePolicy([...chainPolicy], toPolicyStruct(policyNew, chainPolicy.start), backend, 2)
+      rm.replacePolicy([...chainPolicy], toPolicyStruct(policyNew, rm, 2, chainPolicy.start), backend)
     );
 
     const evts = getTransactionEvent(ph.interface, replaceReceipt, "NotificationReceived", false, getAddress(ph));
@@ -189,18 +190,18 @@ describe("PolicyHolder replacement handling", () => {
 
     await ph.setFailReplace(true);
     await expect(
-      rm.replacePolicy([...chainPolicy], toPolicyStruct(policyNew, chainPolicy.start), backend, 2)
+      rm.replacePolicy([...chainPolicy], toPolicyStruct(policyNew, rm, 2, chainPolicy.start), backend)
     ).to.be.revertedWith("onPolicyReplaced: They told me I have to fail");
 
     // Same happens with an empty revert
     await ph.setEmptyRevert(true);
-    await expect(rm.replacePolicy([...chainPolicy], toPolicyStruct(policyNew, chainPolicy.start), backend, 2)).to.be
+    await expect(rm.replacePolicy([...chainPolicy], toPolicyStruct(policyNew, rm, 2, chainPolicy.start), backend)).to.be
       .reverted;
 
     // Also fails if returns wrong value
     await ph.setFailReplace(false);
     await ph.setBadlyImplementedReplace(true);
-    await expect(rm.replacePolicy([...chainPolicy], toPolicyStruct(policyNew, chainPolicy.start), backend, 2))
+    await expect(rm.replacePolicy([...chainPolicy], toPolicyStruct(policyNew, rm, 2, chainPolicy.start), backend))
       .to.be.revertedWithCustomError(pool, "InvalidNotificationResponse")
       .withArgs("0x0badf00d");
   });
@@ -422,7 +423,7 @@ async function deployPoolFixture() {
 }
 
 async function createPolicy(rm, pool, policy, payer, onBehalfOf, internalId) {
-  const tx = await rm.newPolicy(toPolicyStruct(policy), payer, onBehalfOf, internalId);
+  const tx = await rm.newPolicy(toPolicyStruct(policy, rm, internalId), payer, onBehalfOf);
   const receipt = await tx.wait();
 
   return getTransactionEvent(pool.interface, receipt, "NewPolicy");

--- a/test/test-policy-pool.js
+++ b/test/test-policy-pool.js
@@ -13,7 +13,7 @@ const { addEToken, createEToken, deployPool, deployPremiumsAccount } = require("
 const helpers = require("@nomicfoundation/hardhat-network-helpers");
 const { ComponentStatus, ComponentKind } = require("../js/enums.js");
 const hre = require("hardhat");
-const { encodePolicy } = require("../js/utils.js");
+const { makePolicyId, encodePolicy } = require("../js/utils.js");
 const { ethers } = hre;
 const { ZeroAddress, ZeroHash } = ethers;
 
@@ -33,8 +33,9 @@ async function createNewPolicy(
   internalId,
   overrides = {}
 ) {
+  const policyId = makePolicyId(await rm.getAddress(), internalId);
   const policyData = [
-    0, // id - ignored
+    policyId,
     payout,
     overrides.jrScr || _A(0), // jrScr
     overrides.srScr || _A(0), // srScr
@@ -44,15 +45,14 @@ async function createNewPolicy(
     overrides.partnerCommission || _A(0), // partnerCommission
     overrides.jrCoc || _A(0), // jrCoc
     overrides.srCoc || _A(0), // srCoc
-    await helpers.time.latest(),
+    0, // start - RiskModuleMock replaces with block.timestamp
     expiration,
   ];
 
-  const tx = await rm.connect(cust).newPolicy([...policyData], payer, holder, internalId);
+  const tx = await rm.connect(cust).newPolicy([...policyData], payer, holder);
   const receipt = await tx.wait();
   const newPolicyEvt = getTransactionEvent(pool.interface, receipt, "NewPolicy");
-  const policy = newPolicyEvt.args.policy;
-  return policy;
+  return newPolicyEvt.args.policy;
 }
 
 async function deployPoolFixture() {
@@ -114,8 +114,9 @@ async function deployRmWithPolicyFixture() {
   // Deploy a new policy
   await currency.connect(cust).approve(pool, _A(110));
 
+  const policyId = makePolicyId(await rm.getAddress(), 123);
   const policyData = [
-    0, // id - Ignored
+    policyId,
     _A(1000), // payout
     _A(0), // jrScr
     _A(0), // srScr
@@ -125,11 +126,11 @@ async function deployRmWithPolicyFixture() {
     _A(0), // partnerCommission
     _A(0), // jrCoc
     _A(0), // srCoc
-    0, // start
+    0, // start - RiskModuleMock replaces with block.timestamp
     now + HOUR * 5, // expiration
   ];
 
-  const tx = await rm.newPolicy(policyData, cust, cust, 123);
+  const tx = await rm.newPolicy(policyData, cust, cust);
 
   const receipt = await tx.wait();
 
@@ -316,7 +317,7 @@ describe("PolicyPool contract", function () {
       now + HOUR * 5, // expiration
     ];
 
-    await expect(pool.newPolicy(policyData, cust, backend, 11))
+    await expect(pool.newPolicy(policyData, cust, backend))
       .to.be.revertedWithCustomError(pool, "ComponentNotTheRightKind")
       .withArgs(owner, ComponentKind.riskModule);
   });
@@ -425,7 +426,7 @@ describe("PolicyPool contract", function () {
     const { pool, rm, cust, backend, policy } = await helpers.loadFixture(deployRmWithPolicyFixture);
     const now = await helpers.time.latest();
     const policyData = [
-      1, // id
+      policy.id,
       _A(1000), // payout
       _W(0), // jrScr
       _W(0), // srScr
@@ -435,11 +436,11 @@ describe("PolicyPool contract", function () {
       _W(0), // partnerCommission
       _W(0), // jrCoc
       _W(0), // srCoc
-      now, // start
+      0, // start - RiskModuleMock replaces with block.timestamp
       now + HOUR * 5, // expiration
     ];
 
-    await expect(rm.newPolicy(policyData, cust, backend, 123))
+    await expect(rm.newPolicy(policyData, cust, backend))
       .to.be.revertedWithCustomError(pool, "PolicyAlreadyExists")
       .withArgs(policy.id);
   });
@@ -491,7 +492,7 @@ describe("PolicyPool contract", function () {
     const { policy, rm, pool } = await helpers.loadFixture(deployRmWithPolicyFixture);
     await expect(rm.resolvePolicy([...policy], policy.payout)).not.to.be.reverted;
     expect(await pool.isActive(policy.id)).to.be.false;
-    await expect(pool.replacePolicy([...policy], [...policy], ZeroAddress, 1234))
+    await expect(pool.replacePolicy([...policy], [...policy], ZeroAddress))
       .to.be.revertedWithCustomError(pool, "PolicyNotFound")
       .withArgs(policy.id);
   });
@@ -505,18 +506,18 @@ describe("PolicyPool contract", function () {
     const rmNew = PolicyPool.attach(rmMock);
     await pool.addComponent(rmNew, ComponentKind.riskModule);
 
-    await expect(rmNew.replacePolicy([...policy], [...policy], ZeroAddress, 1234)).to.be.revertedWithCustomError(
+    await expect(rmNew.replacePolicy([...policy], [...policy], ZeroAddress)).to.be.revertedWithCustomError(
       pool,
       "OnlyRiskModuleAllowed"
     );
   });
 
-  it("Rejects batch creation with mismatched array lengths", async () => {
+  it("Rejects batch creation with policies not starting now", async () => {
     const { rm, pool, cust } = await helpers.loadFixture(deployRiskModuleFixture);
-    const now = await helpers.time.latest();
+    const policyId = makePolicyId(await rm.getAddress(), 1);
 
     const policyData = [
-      0, // id - Ignored
+      policyId,
       _A(1000), // payout
       _A(0), // jrScr
       _A(0), // srScr
@@ -526,18 +527,17 @@ describe("PolicyPool contract", function () {
       _A(0), // partnerCommission
       _A(0), // jrCoc
       _A(0), // srCoc
-      now,
-      now + HOUR,
+      1, // start != block.timestamp -> triggers NewPoliciesMustStartNow
+      1 + HOUR,
     ];
 
     await expect(
       rm.newPoliciesBatch(
-        [policyData, [...policyData]],
+        [policyData],
         cust.address,
-        cust.address,
-        [1] // Only 1 internalId for 2 policies
+        cust.address
       )
-    ).to.be.revertedWithCustomError(pool, "BatchInputLengthMismatch");
+    ).to.be.revertedWithCustomError(pool, "NewPoliciesMustStartNow");
   });
 
   it("Rejects replace policy if the pool is paused", async () => {
@@ -545,7 +545,7 @@ describe("PolicyPool contract", function () {
 
     await expect(pool.pause()).to.emit(pool, "Paused");
 
-    await expect(pool.replacePolicy([...policy], [...policy], ZeroAddress, 1234)).to.be.revertedWithCustomError(
+    await expect(pool.replacePolicy([...policy], [...policy], ZeroAddress)).to.be.revertedWithCustomError(
       pool,
       "EnforcedPause"
     );
@@ -563,13 +563,13 @@ describe("PolicyPool contract", function () {
     const { policy, pool, rm, premiumsAccount, backend } = await helpers.loadFixture(deployRmWithPolicyFixture);
     await pool.changeComponentStatus(premiumsAccount, ComponentStatus.deprecated);
 
-    await expect(rm.replacePolicy([...policy], [...policy], backend, 1234)).to.be.revertedWithCustomError(
+    await expect(rm.replacePolicy([...policy], [...policy], backend)).to.be.revertedWithCustomError(
       pool,
       "ComponentNotFoundOrNotActive"
     );
     await pool.changeComponentStatus(premiumsAccount, ComponentStatus.active);
     await pool.changeComponentStatus(rm, ComponentStatus.deprecated);
-    await expect(rm.replacePolicy([...policy], [...policy], backend, 1234)).to.be.revertedWithCustomError(
+    await expect(rm.replacePolicy([...policy], [...policy], backend)).to.be.revertedWithCustomError(
       pool,
       "ComponentNotFoundOrNotActive"
     );
@@ -598,7 +598,7 @@ describe("PolicyPool contract", function () {
     await helpers.time.increaseTo(policy.expiration + 100n);
     const newPolicy = [...policy];
     newPolicy[11] += 1000n; // change expiration
-    await expect(rm.replacePolicy([...policy], [...newPolicy], backend, 1234))
+    await expect(rm.replacePolicy([...policy], [...newPolicy], backend))
       .to.be.revertedWithCustomError(pool, "PolicyAlreadyExpired")
       .withArgs(policy.id);
   });
@@ -618,7 +618,7 @@ describe("PolicyPool contract", function () {
     await helpers.time.increaseTo(policy.expiration - BigInt(HOUR));
     const newPolicy = [...policy];
     newPolicy[11] = policy.expiration - BigInt(2 * HOUR); // change expiration
-    await expect(rm.replacePolicy([...policy], [...newPolicy], backend, 1234))
+    await expect(rm.replacePolicy([...policy], [...newPolicy], backend))
       .to.be.revertedWithCustomError(pool, "PolicyAlreadyExpired")
       .withArgs(policy.id);
   });
@@ -635,31 +635,31 @@ describe("PolicyPool contract", function () {
     });
     let p2 = [...p1];
     p2[7] -= _A("0.1"); // decrease partnerCommission
-    await expect(rm.replacePolicy([...p1], [...p2], backend, 1234))
+    await expect(rm.replacePolicy([...p1], [...p2], backend))
       .to.be.revertedWithCustomError(pool, "InvalidPolicyReplacement")
       .withArgs(p1, p2);
 
     p2 = [...p1];
     p2[6] -= _A("0.1"); // decrease ensuroCommission
-    await expect(rm.replacePolicy([...p1], [...p2], backend, 1234))
+    await expect(rm.replacePolicy([...p1], [...p2], backend))
       .to.be.revertedWithCustomError(pool, "InvalidPolicyReplacement")
       .withArgs(p1, p2);
 
     p2 = [...p1];
     p2[8] -= _A("0.1"); // decrease jrCoc
-    await expect(rm.replacePolicy([...p1], [...p2], backend, 1234))
+    await expect(rm.replacePolicy([...p1], [...p2], backend))
       .to.be.revertedWithCustomError(pool, "InvalidPolicyReplacement")
       .withArgs(p1, p2);
 
     p2 = [...p1];
     p2[9] -= _A("0.1"); // decrease srCoc
-    await expect(rm.replacePolicy([...p1], [...p2], backend, 1234))
+    await expect(rm.replacePolicy([...p1], [...p2], backend))
       .to.be.revertedWithCustomError(pool, "InvalidPolicyReplacement")
       .withArgs(p1, p2);
 
     p2 = [...p1];
     p2[5] -= _A("0.1"); // decrease purePremium
-    await expect(rm.replacePolicy([...p1], [...p2], backend, 1234))
+    await expect(rm.replacePolicy([...p1], [...p2], backend))
       .to.be.revertedWithCustomError(pool, "InvalidPolicyReplacement")
       .withArgs(p1, p2);
   });
@@ -670,7 +670,7 @@ describe("PolicyPool contract", function () {
     await helpers.time.increaseTo(policy.start + 100n);
     const now = await helpers.time.latest();
     const p = await createNewPolicy(rm, backend, pool, _A(1000), _A(10), _W(0), now + HOUR * 5, cust, cust, 1234);
-    await expect(rm.replacePolicy([...policy], [...p], backend, 123))
+    await expect(rm.replacePolicy([...policy], [...p], backend))
       .to.be.revertedWithCustomError(pool, "InvalidPolicyReplacement")
       .withArgs(policy, p);
   });
@@ -696,8 +696,10 @@ describe("PolicyPool contract", function () {
     const replacementIRSr = newCaptureAny();
     const originalIRSr = newCaptureAny();
     const adjustmentSr = newCaptureAny();
-    const [oldPolicyId, newPolicyId] = [p1[0], p1[0] - 222n + 234n];
-    await expect(rm.replacePolicy([...p1], [...p2], backend, 234))
+    const newPolicyId = makePolicyId(await rm.getAddress(), 234);
+    p2[0] = newPolicyId;
+    const oldPolicyId = p1[0];
+    await expect(rm.replacePolicy([...p1], [...p2], backend))
       .to.emit(pool, "PolicyReplaced")
       .withArgs(rm, oldPolicyId, newPolicyId)
       .to.emit(jrEtk, "SCRLocked")
@@ -740,8 +742,10 @@ describe("PolicyPool contract", function () {
     const replacementIRSr = newCaptureAny();
     const originalIRSr = newCaptureAny();
     const adjustmentSr = newCaptureAny();
-    const [oldPolicyId, newPolicyId] = [p1[0], p1[0] - 222n + 234n];
-    await expect(rm.replacePolicy([...p1], [...p2], backend, 234))
+    const newPolicyId = makePolicyId(await rm.getAddress(), 234);
+    p2[0] = newPolicyId;
+    const oldPolicyId = p1[0];
+    await expect(rm.replacePolicy([...p1], [...p2], backend))
       .to.emit(pool, "PolicyReplaced")
       .withArgs(rm, oldPolicyId, newPolicyId)
       .to.emit(jrEtk, "SCRLocked")
@@ -776,6 +780,8 @@ describe("PolicyPool contract", function () {
       ensuroCommission: _A("0.1"),
     });
     let p2 = [...p1];
+    const newPolicyId = makePolicyId(await rm.getAddress(), 234);
+    p2[0] = newPolicyId;
     p2[1] = _A(2000); // payout 2x
     p2[2] = _A(50); // jrScr 1/2x
     p2[3] = _A(1000); // srScr 2x
@@ -784,14 +790,14 @@ describe("PolicyPool contract", function () {
     await helpers.time.increaseTo(now + HOUR * 3);
 
     // Check exposure is increased
-    await expect(rm.replacePolicy([...p1], [...p2], backend, 234))
+    await expect(rm.replacePolicy([...p1], [...p2], backend))
       .to.be.revertedWithCustomError(pool, "ExposureLimitExceeded")
       .withArgs(_A(3000), _A(2000));
 
     await pool.setExposureLimit(rm, _A(3000));
 
     // Increase in srCoc requires new allowance
-    await expect(rm.replacePolicy([...p1], [...p2], backend, 234))
+    await expect(rm.replacePolicy([...p1], [...p2], backend))
       .to.be.revertedWithCustomError(currency, "ERC20InsufficientAllowance")
       .withArgs(pool, _A(0), _A("0.4"));
 
@@ -803,8 +809,8 @@ describe("PolicyPool contract", function () {
     const replacementIRSr = newCaptureAny();
     const originalIRSr = newCaptureAny();
     const adjustmentSr = newCaptureAny();
-    const [oldPolicyId, newPolicyId] = [p1[0], p1[0] - 222n + 234n];
-    await expect(rm.replacePolicy([...p1], [...p2], backend, 234))
+    const oldPolicyId = p1[0];
+    await expect(rm.replacePolicy([...p1], [...p2], backend))
       .to.emit(pool, "PolicyReplaced")
       .withArgs(rm, oldPolicyId, newPolicyId)
       .to.emit(jrEtk, "SCRLocked")
@@ -987,7 +993,7 @@ describe("PolicyPool contract", function () {
 
   it("Replacement policy must have a new unique internalId", async () => {
     const { policy, rm, pool, backend } = await helpers.loadFixture(deployRmWithPolicyFixture);
-    await expect(rm.replacePolicy([...policy], [...policy], backend, 123))
+    await expect(rm.replacePolicy([...policy], [...policy], backend))
       .to.be.revertedWithCustomError(pool, "PolicyAlreadyExists")
       .withArgs(policy.id);
   });

--- a/test/test-policy-pool.js
+++ b/test/test-policy-pool.js
@@ -101,7 +101,7 @@ async function deployRiskModuleFixture() {
   const rm = PolicyPool.attach(rmMock);
   await pool.addComponent(rm, ComponentKind.riskModule);
 
-  return { jrEtk, srEtk, premiumsAccount, rm, ...ret };
+  return { jrEtk, srEtk, premiumsAccount, rm, PolicyPool, RiskModuleMock, ...ret };
 }
 
 async function deployRmWithPolicyFixture() {
@@ -497,11 +497,47 @@ describe("PolicyPool contract", function () {
   });
 
   it("Only RM can replace policies", async () => {
-    const { policy, pool } = await helpers.loadFixture(deployRmWithPolicyFixture);
-    await expect(pool.replacePolicy([...policy], [...policy], ZeroAddress, 1234)).to.be.revertedWithCustomError(
+    const { policy, premiumsAccount, lp, pool, RiskModuleMock, PolicyPool } =
+      await helpers.loadFixture(deployRmWithPolicyFixture);
+
+    // Create and add another RM
+    const rmMock = await RiskModuleMock.deploy(pool, premiumsAccount, lp);
+    const rmNew = PolicyPool.attach(rmMock);
+    await pool.addComponent(rmNew, ComponentKind.riskModule);
+
+    await expect(rmNew.replacePolicy([...policy], [...policy], ZeroAddress, 1234)).to.be.revertedWithCustomError(
       pool,
       "OnlyRiskModuleAllowed"
     );
+  });
+
+  it("Rejects batch creation with mismatched array lengths", async () => {
+    const { rm, pool, cust } = await helpers.loadFixture(deployRiskModuleFixture);
+    const now = await helpers.time.latest();
+
+    const policyData = [
+      0, // id - Ignored
+      _A(1000), // payout
+      _A(0), // jrScr
+      _A(0), // srScr
+      5000, // lossProb
+      _A(10), // purePremium
+      _A(0), // ensuroCommission
+      _A(0), // partnerCommission
+      _A(0), // jrCoc
+      _A(0), // srCoc
+      now,
+      now + HOUR,
+    ];
+
+    await expect(
+      rm.newPoliciesBatch(
+        [policyData, [...policyData]],
+        cust.address,
+        cust.address,
+        [1] // Only 1 internalId for 2 policies
+      )
+    ).to.be.revertedWithCustomError(pool, "BatchInputLengthMismatch");
   });
 
   it("Rejects replace policy if the pool is paused", async () => {

--- a/test/test-policy-pool.js
+++ b/test/test-policy-pool.js
@@ -512,7 +512,7 @@ describe("PolicyPool contract", function () {
     );
   });
 
-  it("Rejects batch creation with policies not starting now", async () => {
+  it("Rejects policies that do not start now", async () => {
     const { rm, pool, cust } = await helpers.loadFixture(deployRiskModuleFixture);
     const policyId = makePolicyId(await rm.getAddress(), 1);
 
@@ -527,17 +527,74 @@ describe("PolicyPool contract", function () {
       _A(0), // partnerCommission
       _A(0), // jrCoc
       _A(0), // srCoc
-      1, // start != block.timestamp -> triggers NewPoliciesMustStartNow
+      1, // start != block.timestamp
       1 + HOUR,
     ];
 
+    // Batch path
     await expect(
-      rm.newPoliciesBatch(
-        [policyData],
-        cust.address,
-        cust.address
-      )
+      rm.newPoliciesBatch([policyData], cust.address, cust.address)
     ).to.be.revertedWithCustomError(pool, "NewPoliciesMustStartNow");
+
+    // Single policy path (non-batch)
+    await expect(
+      rm.newPolicy(policyData, cust.address, cust.address)
+    ).to.be.revertedWithCustomError(pool, "NewPoliciesMustStartNow");
+  });
+
+  it("Emits one NewPolicy event per policy in newPoliciesBatch", async () => {
+    const { rm, pool, cust, currency } = await helpers.loadFixture(deployRiskModuleFixture);
+
+    await pool.setExposureLimit(rm, _A(5000));
+
+    const now = await helpers.time.latest();
+    const rmAddress = await rm.getAddress();
+    const n = 3;
+    const policies = [...Array(n)].map((_, i) => {
+      const id = makePolicyId(rmAddress, 100 + i);
+      return [id, _A(1000), _A(0), _A(0), 5000, _A(10), _A(0), _A(0), _A(0), _A(0), 0, now + HOUR];
+    });
+
+    await currency.connect(cust).approve(pool, _A(30));
+
+    const tx = await rm.newPoliciesBatch(policies, cust.address, cust.address);
+    const receipt = await tx.wait();
+
+    const newPolicyEvents = getTransactionEvent(pool.interface, receipt, "NewPolicy", false);
+    expect(newPolicyEvents.length).to.equal(n);
+  });
+
+  it("Rejects batch with policies from different risk modules", async () => {
+    const { rm, pool, cust } = await helpers.loadFixture(deployRiskModuleFixture);
+
+    await pool.setExposureLimit(rm, _A(2000));
+
+    const rmAddress = await rm.getAddress();
+    const goodId = makePolicyId(rmAddress, 1);
+    const badId = makePolicyId(ZeroAddress, 2);
+
+    const now = await helpers.time.latest();
+    const goodPolicy = [goodId, _A(1000), _A(0), _A(0), 5000, _A(10), _A(0), _A(0), _A(0), _A(0), 0, now + HOUR];
+    const badPolicy = [badId, _A(1000), _A(0), _A(0), 5000, _A(10), _A(0), _A(0), _A(0), _A(0), 0, now + HOUR];
+
+    await expect(
+      rm.newPoliciesBatch([goodPolicy, badPolicy], cust.address, cust.address)
+    ).to.be.revertedWithCustomError(pool, "OnlyRiskModuleAllowed");
+  });
+
+  it("Rejects batch with duplicate policy IDs", async () => {
+    const { rm, pool, cust } = await helpers.loadFixture(deployRiskModuleFixture);
+
+    await pool.setExposureLimit(rm, _A(2000));
+
+    const policyId = makePolicyId(await rm.getAddress(), 1);
+    const now = await helpers.time.latest();
+    const policyData = [policyId, _A(1000), _A(0), _A(0), 5000, _A(10), _A(0), _A(0), _A(0), _A(0), 0, now + HOUR];
+
+    await expect(
+      rm.newPoliciesBatch([[...policyData], [...policyData]], cust.address, cust.address)
+    ).to.be.revertedWithCustomError(pool, "PolicyAlreadyExists")
+     .withArgs(policyId);
   });
 
   it("Rejects replace policy if the pool is paused", async () => {

--- a/test/test-policy.js
+++ b/test/test-policy.js
@@ -3,6 +3,7 @@ const hre = require("hardhat");
 const helpers = require("@nomicfoundation/hardhat-network-helpers");
 
 const { amountFunction, _W, getTransactionEvent } = require("@ensuro/utils/js/utils");
+const { makePolicyId } = require("../js/utils");
 
 const _A = amountFunction(6);
 const { ZeroAddress } = hre.ethers;
@@ -55,6 +56,20 @@ describe("Policy initialize", () => {
     expect(policy.srCoc).to.equal(_A(10 * 0.01));
   });
 
+  it("Sets policy.id to makePolicyId(rm, internalId)", async () => {
+    const { pool } = await helpers.loadFixture(poolFixture);
+
+    const internalId = 42;
+    const policyArgs = await makePolicyArgs({ internalId });
+    const tx = await pool.initializeAndEmitPolicy(...policyArgs);
+    const receipt = await tx.wait();
+
+    const policy = getTransactionEvent(pool.interface, receipt, "NewPolicy").args.policy;
+
+    const expectedId = makePolicyId(ZeroAddress, internalId);
+    expect(policy.id).to.equal(expectedId);
+  });
+
   async function poolFixture() {
     const PolicyPool = await hre.ethers.getContractFactory("PolicyPoolMock");
     const pool = await PolicyPool.deploy(ZeroAddress);
@@ -65,6 +80,8 @@ describe("Policy initialize", () => {
   async function makePolicyArgs(options = {}, rmParams = {}) {
     const now = await helpers.time.latest();
     return [
+      options.rm || ZeroAddress, // rm
+      options.internalId || 1, // internalId
       [
         rmParams.moc || _W(1), // moc
         rmParams.jrCollRatio || _W(0), // jrCollRatio

--- a/test/test-risk-module.js
+++ b/test/test-risk-module.js
@@ -207,28 +207,33 @@ describe("RiskModule contract", function () {
       makeInputData({ expiration: now + HOUR * 5, premium: MaxUint256, internalId: 200 + i })
     );
 
-    const capturePolicies = [...Array(5)].map(() => newCaptureAny());
+    const tx = await rm.connect(backend).newPolicies(inputData, cust);
+    const receipt = await tx.wait();
 
-    await expect(rm.connect(backend).newPolicies(inputData, cust))
-      .to.emit(pool, "NewPolicy")
-      .withArgs(rm, capturePolicies[0].value)
-      .to.emit(pool, "NewPolicy")
-      .withArgs(rm, capturePolicies[1].value)
-      .to.emit(pool, "NewPolicy")
-      .withArgs(rm, capturePolicies[2].value)
-      .to.emit(pool, "NewPolicy")
-      .withArgs(rm, capturePolicies[3].value)
-      .to.emit(pool, "NewPolicy")
-      .withArgs(rm, capturePolicies[4].value);
+    // Verify 5 NewPolicy events
+    const newPolicyEvents = getTransactionEvent(pool.interface, receipt, "NewPolicy", false);
+    expect(newPolicyEvents.length).to.equal(5);
 
-    for (const capturedPolicy of capturePolicies) {
-      const createdPolicy = capturedPolicy.lastValue;
+    // Verify each policy's premium breakdown
+    for (let i = 0; i < 5; i++) {
+      const createdPolicy = newPolicyEvents[i].args.policy;
       expect(createdPolicy.partnerCommission).to.equal(0);
       expect(getPremium(createdPolicy)).not.to.equal(createdPolicy.purePremium);
       expect(getPremium(createdPolicy)).to.equal(
         createdPolicy.purePremium + createdPolicy.srCoc + createdPolicy.jrCoc + createdPolicy.ensuroCommission
       );
     }
+
+    // Verify aggregated transfers: only 2 Transfer events (not 10)
+    // With default params and minimum premium, only purePremium and srCoc are non-zero
+    const transferEvents = getTransactionEvent(
+      currency.interface,
+      receipt,
+      "Transfer",
+      false,
+      await currency.getAddress()
+    );
+    expect(transferEvents.length).to.equal(2);
   });
 
   it("Can create a lot of policies with a single call", async () => {
@@ -247,6 +252,63 @@ describe("RiskModule contract", function () {
     await expect(tx).to.emit(pool, "NewPolicy");
     const receipt = await tx.wait();
     console.log(`gasUsed: ${receipt.gasUsed}`);
+  });
+
+  async function deployFullComponentsFixture() {
+    const { pool, currency } = await helpers.loadFixture(deployPoolFixture);
+    const srEtk = await addEToken(pool, {});
+    const jrEtk = await addEToken(pool, {});
+    const premiumsAccount = await deployPremiumsAccount(pool, { srEtk, jrEtk });
+
+    await currency.connect(lp).approve(pool, _A(5000));
+    await pool.connect(lp).deposit(srEtk, _A(4000), lp);
+    await pool.connect(lp).deposit(jrEtk, _A(1000), lp);
+
+    const FullTrustedUW = await hre.ethers.getContractFactory("FullTrustedUW");
+    const uw = await FullTrustedUW.deploy();
+    const rm = await addRiskModule(pool, premiumsAccount, { underwriter: uw });
+    const now = await helpers.time.latest();
+
+    return { srEtk, jrEtk, premiumsAccount, rm, pool, currency, uw, now };
+  }
+
+  it("Batch creation aggregates premium into exactly 5 ERC20 transfers", async () => {
+    const { rm, pool, currency, now } = await helpers.loadFixture(deployFullComponentsFixture);
+
+    await pool.setExposureLimit(rm, _A(11000));
+
+    // Params that produce all 5 premium components: purePremium, srCoc, jrCoc, ensuroCommission, partnerCommission
+    const params = {
+      jrCollRatio: _W("0.2"),
+      collRatio: _W("1.0"),
+      ensuroPpFee: _W("0.1"),
+    };
+
+    const n = 5;
+    const premium = _A(200);
+    await currency.connect(backend).approve(pool, premium * BigInt(n));
+
+    const inputData = [...Array(n)].map((_, i) =>
+      makeInputData({
+        expiration: now + HOUR * 5,
+        premium,
+        internalId: 200 + i,
+        params,
+      })
+    );
+
+    const tx = await rm.connect(backend).newPolicies(inputData, cust);
+    const receipt = await tx.wait();
+
+    const transferEvents = getTransactionEvent(
+      currency.interface,
+      receipt,
+      "Transfer",
+      false,
+      await currency.getAddress()
+    );
+
+    expect(transferEvents.length).to.equal(5);
   });
 
   it("Can create policies using FullSignedUW", async () => {

--- a/test/test-risk-module.js
+++ b/test/test-risk-module.js
@@ -242,7 +242,11 @@ describe("RiskModule contract", function () {
       makeInputData({ expiration: now + HOUR * 5, premium: MaxUint256, internalId: 200 + i, payout: _A(100) })
     );
 
-    await expect(rm.connect(backend).newPolicies(inputData, cust)).to.emit(pool, "NewPolicy");
+    const tx = await rm.connect(backend).newPolicies(inputData, cust);
+
+    await expect(tx).to.emit(pool, "NewPolicy");
+    const receipt = await tx.wait();
+    console.log(`gasUsed: ${receipt.gasUsed}`);
   });
 
   it("Can create policies using FullSignedUW", async () => {

--- a/test/test-supports-interface.js
+++ b/test/test-supports-interface.js
@@ -59,7 +59,8 @@ describe("Supports interface implementation", function () {
       // IPolicyPool: "0x7d73446f", - Before `refactoring-rms` branch that changed Policy struct
       // IPolicyPool: "0xea84868b", - Before `permit-operate-on-behalf` branch that changed deposit/withdraw
       // IPolicyPool: "0xab249cf4", - Before `policy-cancellation` branch
-      IPolicyPool: "0xc4769787",
+      // IPolicyPool: "0xc4769787", - Before `feat/new-policies-batch` branch
+      IPolicyPool: "0xc3d77bad",
       IPolicyPoolComponent: "0x4d15eb03",
       // IRiskModule: "0xda40804f", - Up to v2.9
       IRiskModule: "0x21b7e09b",

--- a/test/test-supports-interface.js
+++ b/test/test-supports-interface.js
@@ -60,7 +60,7 @@ describe("Supports interface implementation", function () {
       // IPolicyPool: "0xea84868b", - Before `permit-operate-on-behalf` branch that changed deposit/withdraw
       // IPolicyPool: "0xab249cf4", - Before `policy-cancellation` branch
       // IPolicyPool: "0xc4769787", - Before `feat/new-policies-batch` branch
-      IPolicyPool: "0xc3d77bad",
+      IPolicyPool: "0xbbf6be62",
       IPolicyPoolComponent: "0x4d15eb03",
       // IRiskModule: "0xda40804f", - Up to v2.9
       IRiskModule: "0x21b7e09b",

--- a/test/test-upgrade-permissions.js
+++ b/test/test-upgrade-permissions.js
@@ -2,7 +2,7 @@ const { expect } = require("chai");
 const helpers = require("@nomicfoundation/hardhat-network-helpers");
 const { amountFunction } = require("@ensuro/utils/js/utils");
 const { initCurrency } = require("@ensuro/utils/js/test-utils");
-const { deployAMPProxy, getAccessManager } = require("@ensuro/access-managed-proxy/js/deployProxy");
+const { deployAMPProxy, getAccessManager, attachAsAMP } = require("@ensuro/access-managed-proxy/js/deployProxy");
 const { deployPool, deployPremiumsAccount, addRiskModule, addEToken, makeAllPublic } = require("../js/test-utils");
 const { ampConfig } = require("../js/ampConfig");
 
@@ -99,6 +99,28 @@ describe("Test Upgrade contracts", function () {
       pool,
       "UpgradeCannotChangeCurrency"
     );
+  });
+
+  it("Can update pass-thru methods during upgrade via reinitializePashThruMethods", async () => {
+    const { pool, guardian, currency } = await helpers.loadFixture(setupFixtureWithPool);
+    const poolAsAMP = await attachAsAMP(pool);
+
+    const oldMethods = await poolAsAMP.PASS_THRU_METHODS();
+    expect(oldMethods.length).to.be.greaterThan(0);
+
+    // Compute a new set removing the last method to prove replacement works
+    const newSelectors = oldMethods.slice(0, oldMethods.length - 1);
+
+    const PolicyPool = await hre.ethers.getContractFactory("PolicyPool");
+    const newImpl = await PolicyPool.deploy(currency);
+    const data = PolicyPool.interface.encodeFunctionData("reinitializePashThruMethods", [newSelectors]);
+
+    await expect(pool.connect(guardian).upgradeToAndCall(newImpl, data))
+      .to.emit(pool, "PassThruMethodsChanged")
+      .withArgs(newSelectors);
+
+    const updatedMethods = await poolAsAMP.PASS_THRU_METHODS();
+    expect(updatedMethods).to.deep.equal(newSelectors);
   });
 
   it("Should be able to upgrade EToken", async () => {

--- a/test/test-upgrade-permissions.js
+++ b/test/test-upgrade-permissions.js
@@ -101,7 +101,7 @@ describe("Test Upgrade contracts", function () {
     );
   });
 
-  it("Can update pass-thru methods during upgrade via reinitializePashThruMethods", async () => {
+  it("Can update pass-thru methods during upgrade via reinitializePassThruMethods", async () => {
     const { pool, guardian, currency } = await helpers.loadFixture(setupFixtureWithPool);
     const poolAsAMP = await attachAsAMP(pool);
 
@@ -113,7 +113,7 @@ describe("Test Upgrade contracts", function () {
 
     const PolicyPool = await hre.ethers.getContractFactory("PolicyPool");
     const newImpl = await PolicyPool.deploy(currency);
-    const data = PolicyPool.interface.encodeFunctionData("reinitializePashThruMethods", [newSelectors]);
+    const data = PolicyPool.interface.encodeFunctionData("reinitializePassThruMethods", [newSelectors]);
 
     await expect(pool.connect(guardian).upgradeToAndCall(newImpl, data))
       .to.emit(pool, "PassThruMethodsChanged")


### PR DESCRIPTION
Adds a new `newPoliciesBatch` method to PolicyPool that creates multiple
policies in a single call, summing premium components and performing only
one ERC20 transfer per component (purePremium, srCoc, jrCoc,
ensuroCommission, partnerCommission) instead of one per policy. This
reduces the transfers from 5N to 5 for N policies.

`RiskModule.newPolicies()` is updated to price all policies upfront and
call `newPoliciesBatch`, replacing the previous per-policy loop over
`newPolicy()`.