### PR TITLE
fix(WEToken): normalize share scale so 1 WEToken = 1 EToken at initial scale

### DIFF
--- a/contracts/WEToken.sol
+++ b/contracts/WEToken.sol
@@ -5,6 +5,7 @@ import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {ERC4626} from "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
 import {ERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {IEToken} from "./interfaces/IEToken.sol";
@@ -19,17 +20,30 @@ interface IETokenWithWhitelist is IEToken {
 /**
  * @title WEToken - Non-rebasing ERC-4626 wrapper for Ensuro EToken
  * @notice Wraps the rebasing EToken into a non-rebasing ERC-4626 vault token with static balances.
- *         1 WEToken (share) = 1 unit of scaled balance in the underlying EToken.
+ *         1 WEToken (share) is worth 1 eToken at the eToken's initial scale ({ETKLib.SCALE_INITIAL}).
  *         As the EToken accrues yield, each WEToken becomes redeemable for more eTokens.
  * @dev The conversion between eTokens (assets) and WETokens (shares) uses {IEToken-getCurrentScale}:
- *        shares = assets * WAD / scale
- *        assets = shares * scale / WAD
+ *        shares = assets * _shareScale / scale
+ *        assets = shares * scale / _shareScale
+ *      where `_shareScale = SCALE_INITIAL * 10**decimals` (computed at construction) normalizes the
+ *      share unit so that 1 WEToken = 1 eToken when the eToken has no accrued returns.
  *      If the underlying eToken has a whitelist, this contract's address must be whitelisted.
  * @custom:security-contact security@ensuro.co
  * @author Ensuro
  */
 contract WEToken is ERC4626, ERC20Permit, Ownable {
   uint256 internal constant WAD = 1e18;
+
+  /// @notice Initial scale of the underlying eToken (see {ETKLib.SCALE_INITIAL}), in WAD.
+  uint256 internal constant SCALE_INITIAL = 1e14;
+
+  /**
+   * @notice Factor that maps 1 eToken base unit (at the initial scale) to WEToken base units.
+   * @dev `SCALE_INITIAL * 10**(WEToken decimals - eToken decimals)`. For an eToken with 6 decimals
+   *      this equals 1e26: at the initial scale, shares = assets * 1e26 / 1e14 = assets * 1e12,
+   *      so 1 eToken (1e6) wraps into exactly 1 WEToken (1e18).
+   */
+  uint256 internal immutable _shareScale;
 
   /// @notice Thrown when a transfer is attempted from a frozen account
   error FrozenAccount(address account);
@@ -42,6 +56,9 @@ contract WEToken is ERC4626, ERC20Permit, Ownable {
 
   /// @notice Thrown when freezer is address(0) and the eToken has no whitelist to validate against
   error NoWhitelistConfigured();
+
+  /// @notice Thrown when the underlying eToken has more than 18 decimals (can't be represented in the share scale)
+  error InvalidAssetDecimals(uint8 decimals);
 
   /// @notice Emitted when an account is frozen or unfrozen
   event AccountFrozen(address indexed account, bool frozen);
@@ -79,6 +96,9 @@ contract WEToken is ERC4626, ERC20Permit, Ownable {
     address freezer_,
     address owner_
   ) ERC4626(IERC20(address(eToken_))) ERC20(name_, symbol_) ERC20Permit(name_) Ownable(owner_) {
+    uint8 eTokenDecimals = IERC20Metadata(address(eToken_)).decimals();
+    require(eTokenDecimals <= 18, InvalidAssetDecimals(eTokenDecimals));
+    _shareScale = SCALE_INITIAL * 10 ** (18 - eTokenDecimals);
     _setFreezer(freezer_);
   }
 
@@ -89,12 +109,12 @@ contract WEToken is ERC4626, ERC20Permit, Ownable {
 
   /// @dev Uses the eToken scale directly rather than the totalAssets/totalSupply ratio.
   function _convertToShares(uint256 assets, Math.Rounding rounding) internal view override returns (uint256) {
-    return Math.mulDiv(assets, WAD, IEToken(asset()).getCurrentScale(true), rounding);
+    return Math.mulDiv(assets, _shareScale, IEToken(asset()).getCurrentScale(true), rounding);
   }
 
   /// @dev Uses the eToken scale directly rather than the totalAssets/totalSupply ratio.
   function _convertToAssets(uint256 shares, Math.Rounding rounding) internal view override returns (uint256) {
-    return Math.mulDiv(shares, IEToken(asset()).getCurrentScale(true), WAD, rounding);
+    return Math.mulDiv(shares, IEToken(asset()).getCurrentScale(true), _shareScale, rounding);
   }
 
   /**

--- a/test/test-wetoken.js
+++ b/test/test-wetoken.js
@@ -12,6 +12,8 @@ const { ZeroAddress, MaxUint256 } = ethers;
 
 const _A = amountFunction(6);
 const WAD = _W(1);
+// Share scale so 1 WEToken = 1 eToken at the eToken's initial scale: SCALE_INITIAL * 10^(18-6)
+const SHARE_SCALE = SCALE_INITIAL * 10n ** 12n;
 
 describe("WEToken", () => {
   async function wetokenFixture() {
@@ -56,8 +58,8 @@ describe("WEToken", () => {
   it("Deposits eTokens for WETokens at initial scale", async () => {
     const { etk, wetk, lp } = await helpers.loadFixture(wetokenFixture);
     const etkAmount = _A(1000);
-    // shares = assets * WAD / scale; at SCALE_INITIAL each eToken unit gives 10000 WEToken units
-    const expectedWetk = (etkAmount * WAD) / SCALE_INITIAL;
+    // shares = assets * SHARE_SCALE / scale; at SCALE_INITIAL 1 eToken gives exactly 1 WEToken
+    const expectedWetk = (etkAmount * SHARE_SCALE) / SCALE_INITIAL;
 
     expect(await wetk.convertToShares(etkAmount)).to.equal(expectedWetk);
     await expect(wetk.connect(lp).deposit(etkAmount, lp.address))
@@ -70,7 +72,7 @@ describe("WEToken", () => {
   it("Redeems WETokens for eTokens at initial scale", async () => {
     const { etk, wetk, lp } = await helpers.loadFixture(wetokenFixture);
     const etkAmount = _A(1000);
-    const expectedWetk = (etkAmount * WAD) / SCALE_INITIAL;
+    const expectedWetk = (etkAmount * SHARE_SCALE) / SCALE_INITIAL;
     await wetk.connect(lp).deposit(etkAmount, lp.address);
 
     expect(await wetk.convertToAssets(expectedWetk)).to.equal(etkAmount);
@@ -85,7 +87,7 @@ describe("WEToken", () => {
     const { etk, wetk, lp } = await helpers.loadFixture(wetokenFixture);
     const etkBefore = await etk.balanceOf(lp);
     const etkAmount = _A(1000);
-    const wetkMinted = (etkAmount * WAD) / SCALE_INITIAL;
+    const wetkMinted = (etkAmount * SHARE_SCALE) / SCALE_INITIAL;
 
     await wetk.connect(lp).deposit(etkAmount, lp.address);
     await wetk.connect(lp).redeem(wetkMinted, lp.address, lp.address);
@@ -96,16 +98,16 @@ describe("WEToken", () => {
 
   it("Conversion view functions return correct rates at initial scale", async () => {
     const { wetk } = await helpers.loadFixture(wetokenFixture);
-    // convertToAssets(WAD) = WAD * scale / WAD = scale
-    expect(await wetk.convertToAssets(WAD)).to.equal(SCALE_INITIAL);
-    // convertToShares(WAD) = WAD * WAD / scale
-    expect(await wetk.convertToShares(WAD)).to.equal((WAD * WAD) / SCALE_INITIAL);
+    // convertToAssets(WAD) = WAD * scale / SHARE_SCALE = 1e6 (= 1 eToken)
+    expect(await wetk.convertToAssets(WAD)).to.equal(10n ** 6n);
+    // convertToShares(WAD) = WAD * SHARE_SCALE / scale
+    expect(await wetk.convertToShares(WAD)).to.equal((WAD * SHARE_SCALE) / SCALE_INITIAL);
   });
 
   it("WETokens gain value as yield accrues", async () => {
     const { etk, wetk, lp, yieldVault } = await helpers.loadFixture(wetokenWithYieldFixture);
     const etkAmount = _A(1000);
-    const wetkMinted = (etkAmount * WAD) / SCALE_INITIAL;
+    const wetkMinted = (etkAmount * SHARE_SCALE) / SCALE_INITIAL;
     await wetk.connect(lp).deposit(etkAmount, lp.address);
 
     // Generate yield: move USDC to vault, earn 100 USDC (etk receives ~50 due to virtual share)
@@ -113,8 +115,47 @@ describe("WEToken", () => {
     await yieldVault.discreteEarning(_A(100));
     await etk.recordEarnings();
 
-    expect(await wetk.convertToAssets(WAD)).to.be.gt(SCALE_INITIAL);
+    // 1 WEToken was worth 1 eToken (1e6 base units) at the initial scale and appreciates with the yield
+    expect(await wetk.convertToAssets(WAD)).to.be.gt(10n ** 6n);
     expect(await wetk.convertToAssets(wetkMinted)).to.be.gt(etkAmount);
+  });
+
+  it("Redeeming dust WEToken shares floors the eToken amount; below 1e-6 WEToken no eToken is received", async () => {
+    const { etk, wetk, lp } = await helpers.loadFixture(wetokenFixture);
+    await wetk.connect(lp).deposit(_A(1000), lp.address);
+
+    let etkBalance = await etk.balanceOf(lp);
+    let wetkBalance = await wetk.balanceOf(lp);
+
+    // Redeem from 0.1 WEToken down to 0.000000000000000001 (1 base unit)
+    for (let exp = 17n; exp >= 0n; exp--) {
+      const shares = 10n ** exp;
+      const expectedAssets = (shares * SCALE_INITIAL) / SHARE_SCALE; // floors to 0 for dust
+      expect(await wetk.previewRedeem(shares)).to.equal(expectedAssets);
+
+      await wetk.connect(lp).redeem(shares, lp.address, lp.address);
+
+      etkBalance += expectedAssets;
+      wetkBalance -= shares;
+      expect(await etk.balanceOf(lp)).to.equal(etkBalance);
+      expect(await wetk.balanceOf(lp)).to.equal(wetkBalance);
+    }
+  });
+
+  it("Dust threshold: 1e-6 WEToken redeems exactly 1 eToken base unit, 1 unit less redeems nothing", async () => {
+    const { etk, wetk, lp } = await helpers.loadFixture(wetokenFixture);
+    await wetk.connect(lp).deposit(_A(1000), lp.address);
+
+    const etkBefore = await etk.balanceOf(lp);
+    const threshold = SHARE_SCALE / SCALE_INITIAL; // 1e12 shares = 1e-6 WEToken
+
+    expect(await wetk.previewRedeem(threshold - 1n)).to.equal(0n);
+    await wetk.connect(lp).redeem(threshold - 1n, lp.address, lp.address);
+    expect(await etk.balanceOf(lp)).to.equal(etkBefore);
+
+    expect(await wetk.previewRedeem(threshold)).to.equal(1n);
+    await wetk.connect(lp).redeem(threshold, lp.address, lp.address);
+    expect(await etk.balanceOf(lp)).to.equal(etkBefore + 1n);
   });
 
   it("setFreezer can only be called by owner", async () => {


### PR DESCRIPTION
## What
Fixes the decimal representation of WEToken. The conversion previously used the raw eToken scale (`shares = assets * WAD / scale`). Because the eToken's initial scale is `1e14` (0.0001 WAD), wrapping 1 eToken produced `1e10` shares, which at 18 decimals displayed as `0.00000001` WEToken.

## Change
Anchor the share unit to the eToken's initial scale via an immutable `_shareScale = SCALE_INITIAL * 10**(18 - eTokenDecimals)`, computed at construction. With this:
- **1 WEToken = 1 eToken** when the eToken has no accrued returns.
- As the eToken accrues yield, each WEToken redeems for proportionally more eTokens (at 10% return, 1 eToken wraps into ~0.9091 WEToken, i.e. `1/1.1`).

## Tests
- Updated existing conversion expectations (deposit/redeem/round-trip, `convertToAssets(WAD) = 1e6`, `convertToShares(WAD) = 1e30`).
- Added dust-threshold tests: share redemptions floor to 0 eTokens below `1e-6` WEToken; the boundary at `1e-6` WEToken redeems exactly 1 eToken base unit.